### PR TITLE
feat: relocate principal extraction code to pkg

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,9 +4,10 @@ go 1.18
 
 require (
 	cloud.google.com/go/compute v1.6.1
+	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/google/go-cmp v0.5.8
 	go.uber.org/zap v1.21.0
-	google.golang.org/grpc v1.46.2
+	google.golang.org/grpc v1.47.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeME
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
+github.com/golang-jwt/jwt v3.2.2+incompatible h1:IfV12K8xAKAnZqdXVzCZ+TOjboZ2keLg81eXfW3O+oY=
+github.com/golang-jwt/jwt v3.2.2+incompatible/go.mod h1:8pz2t5EyA70fFQQSrl6XZXzqecmYZeUEB8OUGHkxJ+I=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -591,8 +593,8 @@ google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9K
 google.golang.org/grpc v1.40.1/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
 google.golang.org/grpc v1.44.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc v1.45.0/go.mod h1:lN7owxKUQEqMfSyQikvvk5tf/6zMPsrK+ONuO11+0rQ=
-google.golang.org/grpc v1.46.2 h1:u+MLGgVf7vRdjEYZ8wDFhAVNmhkbJ5hmrA1LMWK1CAQ=
-google.golang.org/grpc v1.46.2/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
+google.golang.org/grpc v1.47.0 h1:9n77onPX5F3qfFCqjy9dhn8PbNQsIKeVU04J9G7umt8=
+google.golang.org/grpc v1.47.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/security/grpc.go
+++ b/security/grpc.go
@@ -1,0 +1,124 @@
+// Copyright 2022 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package security describes the authentication technology that the
+// middleware investigates to autofill the principal in a log request.
+package security
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/golang-jwt/jwt"
+	grpcmetadata "google.golang.org/grpc/metadata"
+)
+
+// Key in a JWT's `claims` where we expect the principal.
+const emailKey = "email"
+
+// GRPCContext is an interface that retrieves the principal
+// from a gRPC security context. A gRPC security context describes
+// the technology used to authenticate a principal (e.g. JWT).
+type GRPCContext interface {
+	RequestPrincipal(context.Context) (string, error)
+}
+
+// JWKs provides JWKs to validate a JWT.
+type JWKs struct {
+	// Endpoint is the endpoint to retrieve the JWKs to validate JWT.
+	Endpoint string `yaml:"endpoint,omitempty"`
+}
+
+// JWTRule provides info for how to retrieve security context from
+// a raw JWT.
+type JWTRule struct {
+	// Key is the metadata key whose value is a JWT.
+	Key string `yaml:"key,omitempty"`
+	// Prefix is the prefix to truncate the metadata value
+	// to retrieve the JWT.
+	Prefix string `yaml:"prefix,omitempty"`
+	// JWKs specifies the JWKs to validate the JWT.
+	// If JWTs is nil, the JWT won't be validated.
+	JWKs *JWKs `yaml:"jwks,omitempty"`
+}
+
+// Validate validates the FromRawJWT.
+func (j *JWTRule) Validate() error {
+	if j.Key == "" {
+		return fmt.Errorf("key must be specified")
+	}
+	return nil
+}
+
+// JWTRules is a list of JWTRules used to retrieve security context from raw JWTs.
+type JWTRules struct {
+	Rules []*JWTRule `yaml:"jwt_rules,omitempty"`
+}
+
+// RequestPrincipal extracts the JWT principal from the grpcmetadata in the context.
+// TODO: This method does not verify the JWT #20.
+func (j *JWTRules) RequestPrincipal(ctx context.Context) (string, error) {
+	md, ok := grpcmetadata.FromIncomingContext(ctx)
+	if !ok {
+		return "", fmt.Errorf("gRPC metadata in incoming context is missing")
+	}
+
+	idToken, err := j.findJWT(md)
+	if err != nil {
+		return "", err
+	}
+
+	// Parse the JWT into claims.
+	p := &jwt.Parser{}
+	claims := jwt.MapClaims{}
+	if _, _, err := p.ParseUnverified(idToken, claims); err != nil {
+		return "", fmt.Errorf("unable to parse JWT: %w", err)
+	}
+
+	// Retrieve the principal from claims.
+	principalRaw, ok := claims[emailKey]
+	if !ok {
+		return "", fmt.Errorf("jwt claims are missing the email key %q", emailKey)
+	}
+	principal, ok := principalRaw.(string)
+	if !ok {
+		return "", fmt.Errorf("expecting string in jwt claims %q, got %T", emailKey, principalRaw)
+	}
+	if principal == "" {
+		return "", fmt.Errorf("nil principal under claims %q", emailKey)
+	}
+
+	return principal, nil
+}
+
+// findJWT looks for a JWT from the gRPC metadata that matches the rules.
+func (j *JWTRules) findJWT(md grpcmetadata.MD) (string, error) {
+	for _, fj := range j.Rules {
+		// Keys in grpc metadata are all lowercases.
+		vals := md.Get(fj.Key)
+		if len(vals) == 0 {
+			continue
+		}
+		jwtRaw := vals[0]
+		// We compare prefix case insensitively.
+		if !strings.HasPrefix(strings.ToLower(jwtRaw), strings.ToLower(fj.Prefix)) {
+			continue
+		}
+		idToken := jwtRaw[len(fj.Prefix):]
+		return idToken, nil
+	}
+
+	return "", fmt.Errorf("no JWT found matching rules: %#v", j.Rules)
+}

--- a/security/grpc_test.go
+++ b/security/grpc_test.go
@@ -1,0 +1,166 @@
+// Copyright 2022 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package security describes the authentication technology that the
+// middleware investigates to autofill the principal in a log request.
+package security
+
+import (
+	"context"
+	"testing"
+
+	"github.com/abcxyz/pkg/testutil"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestFromRawJWT_RequestPrincipal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		ctx           context.Context //nolint:containedctx // Only for testing
+		jwtRule       []*JWTRule
+		want          string
+		wantErrSubstr string
+	}{
+		{
+			name: "valid_jwt",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+				"authorization": "Bearer " + testutil.JWTFromClaims(t, map[string]interface{}{
+					"email": "user@example.com",
+				}),
+			})),
+			jwtRule: []*JWTRule{{
+				Key:    "authorization",
+				Prefix: "Bearer ",
+			}},
+			want: "user@example.com",
+		},
+		{
+			name: "valid_jwt_with_capitalized_config",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+				"authorization": "bearer " + testutil.JWTFromClaims(t, map[string]interface{}{
+					"email": "user@example.com",
+				}),
+			})),
+			jwtRule: []*JWTRule{{
+				Key:    "Authorization",
+				Prefix: "Bearer ",
+			}},
+			want: "user@example.com",
+		},
+		{
+			name: "multi_jwts",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+				"x-jwt-assertion": testutil.JWTFromClaims(t, map[string]interface{}{
+					"email": "user@example.com",
+				}),
+			})),
+			jwtRule: []*JWTRule{{
+				Key:    "authorization",
+				Prefix: "Bearer ",
+			}, {
+				Key: "x-jwt-assertion",
+			}},
+			want: "user@example.com",
+		},
+		{
+			name: "error_from_missing_jwt_email_claim",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+				"authorization": "Bearer " + testutil.JWTFromClaims(t, map[string]interface{}{}),
+			})),
+			jwtRule: []*JWTRule{{
+				Key:    "authorization",
+				Prefix: "Bearer ",
+			}},
+			wantErrSubstr: `jwt claims are missing the email key "email"`,
+		},
+		{
+			name: "error_from_slice_as_jwt_email_claim",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+				"authorization": "Bearer " + testutil.JWTFromClaims(t, map[string]interface{}{
+					"email": []string{"foo", "bar"},
+				}),
+			})),
+			jwtRule: []*JWTRule{{
+				Key:    "authorization",
+				Prefix: "Bearer ",
+			}},
+			wantErrSubstr: `expecting string in jwt claims "email", got []interface {}`,
+		},
+		{
+			name:          "error_from_missing_grpc_metadata",
+			ctx:           context.Background(),
+			wantErrSubstr: "gRPC metadata in incoming context is missing",
+		},
+		{
+			name: "error_from_inexistent_jwt_key",
+			ctx:  metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{})),
+			jwtRule: []*JWTRule{{
+				Key:    "authorization",
+				Prefix: "Bearer ",
+			}},
+			wantErrSubstr: `no JWT found matching rules`,
+		},
+		{
+			name: "error_from_prefix_longer_than_jwt",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+				"authorization": "short",
+			})),
+			jwtRule: []*JWTRule{{
+				Key:    "authorization",
+				Prefix: "loooooong",
+			}},
+			wantErrSubstr: `no JWT found matching rules`,
+		},
+		{
+			name: "error_from_empty_string_as_jwt",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+				"authorization": "",
+			})),
+			jwtRule: []*JWTRule{{
+				Key:    "authorization",
+				Prefix: "",
+			}},
+			wantErrSubstr: `unable to parse JWT: token contains an invalid number of segments`,
+		},
+		{
+			name: "error_from_unparsable_jwt",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.New(map[string]string{
+				"authorization": "bananas",
+			})),
+			jwtRule: []*JWTRule{{
+				Key:    "authorization",
+				Prefix: "",
+			}},
+			wantErrSubstr: "unable to parse JWT",
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			j := &JWTRules{Rules: tc.jwtRule}
+			got, err := j.RequestPrincipal(tc.ctx)
+			if diff := testutil.DiffErrString(err, tc.wantErrSubstr); diff != "" {
+				t.Errorf("j.RequestPrincipal()) got unexpected error substring: %v", diff)
+			}
+
+			if got != tc.want {
+				t.Errorf("j.RequestPrincipal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/testutil/jwt.go
+++ b/testutil/jwt.go
@@ -1,0 +1,35 @@
+// Copyright 2022 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"testing"
+
+	"github.com/golang-jwt/jwt"
+)
+
+// JWTFromClaims is a testing helper that builds a JWT from the
+// given claims.
+func JWTFromClaims(tb testing.TB, claims map[string]interface{}) string {
+	tb.Helper()
+
+	var jwtMapClaims jwt.MapClaims = claims
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwtMapClaims)
+	signedToken, err := token.SignedString([]byte("secureSecretText"))
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return signedToken
+}


### PR DESCRIPTION
We will need principal extraction for Lumberjack, JVS, and probably future services as well. I've copied over the existing code from Lumberjack ( https://github.com/abcxyz/lumberjack/blob/main/clients/go/pkg/security/grpc.go#L42 , https://github.com/abcxyz/lumberjack/blob/main/clients/go/apis/v1alpha1/config.go#L267 ) with minor modifications 

- renamed struct to be more obvious, i found the name FromRawJWT to be a bit confusing, especially as it was used to name both an individual JWT rule and a group of rules
- Added TODO for JWT validation. Will follow up in another PR, but the existing code does no validation of the JWTs. https://github.com/abcxyz/pkg/issues/20