### PR TITLE
chore: increase timeout

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -109,7 +109,7 @@ jobs:
               "unused",
               "varcheck",
               "whitespace",
-            ]'), ',') }} --max-issues-per-linter=0 --max-same-issues=0
+            ]'), ',') }} --max-issues-per-linter=0 --max-same-issues=0 --timeout=5m
           working-directory: '${{ inputs.directory }}'
 
       - name: 'Lint (custom configuration)'


### PR DESCRIPTION
The golang lint run keeps timing out. These increases the timeout. see https://golangci-lint.run/usage/configuration/#command-line-options

[Example of a timed out run ](https://github.com/abcxyz/jvs/runs/7419521167?check_suite_focus=true)