### PR TITLE
Add helper for making a logger tied to a test context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	cloud.google.com/go/compute v1.10.0
 	github.com/go-sql-driver/mysql v1.6.0
-	github.com/google/go-cmp v0.5.8
+	github.com/google/go-cmp v0.5.9
 	github.com/lestrrat-go/jwx/v2 v2.0.6
 	github.com/ory/dockertest/v3 v3.9.1
 	github.com/sethvargo/go-envconfig v0.8.2
@@ -18,6 +18,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 // indirect
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
+	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -7,7 +7,8 @@ github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VM
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
-github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
+github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
+github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/checkpoint-restore/go-criu/v5 v5.3.0/go.mod h1:E/eQpaFtUKGOOSEBZgmKAcn+zUUwWxqcaKZlF54wK8E=
@@ -51,8 +52,8 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
-github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
+github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
 github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -26,6 +26,7 @@ import (
 	"cloud.google.com/go/compute/metadata"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
 	"google.golang.org/grpc"
 	grpcmetadata "google.golang.org/grpc/metadata"
 )
@@ -104,6 +105,20 @@ func FromContext(ctx context.Context) *zap.SugaredLogger {
 		return logger
 	}
 	return Default()
+}
+
+// TestLogger returns a logger configured for tests. It will only output log
+// information if specific test fails or is run in verbose mode. See [zaptest]
+// for more information.
+//
+//	func TestMyThing(t *testing.T) {
+//		logger := logging.TestLogger(t)
+//		thing := &MyThing{logger: logger}
+//	}
+//
+// [zaptest]: https://pkg.go.dev/go.uber.org/zap/zaptest
+func TestLogger(tb zaptest.TestingT) *zap.SugaredLogger {
+	return zaptest.NewLogger(tb, zaptest.Level(zap.WarnLevel)).Sugar()
 }
 
 // GRPCInterceptor returns a gRPC interceptor that populates a logger in the context.

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -22,6 +22,8 @@ import (
 )
 
 func TestContext(t *testing.T) {
+	t.Parallel()
+
 	logger1 := zap.NewNop().Sugar()
 	logger2 := zap.NewExample().Sugar()
 
@@ -34,9 +36,10 @@ func TestContext(t *testing.T) {
 	checkFromContext(ctx, t, logger2)
 }
 
-func checkFromContext(ctx context.Context, t *testing.T, want *zap.SugaredLogger) {
-	t.Helper()
+func checkFromContext(ctx context.Context, tb testing.TB, want *zap.SugaredLogger) {
+	tb.Helper()
+
 	if got := FromContext(ctx); want != got {
-		t.Errorf("unexpected logger in context. got: %v, want: %v", got, want)
+		tb.Errorf("unexpected logger in context. got: %v, want: %v", got, want)
 	}
 }


### PR DESCRIPTION
This adds a new function to the logging package that enables us to couple the logger to the testing context. This will clean up test output and ensure we only see log messages relevant to the failed test(s).