### PR TITLE
Set up a reusable action to setup necessary tools. For ex: skaffold

### DIFF
--- a/.github/actions/setup-e2e-tools/action.yml
+++ b/.github/actions/setup-e2e-tools/action.yml
@@ -1,0 +1,13 @@
+name: 'setup-e2e-tools'
+description: 'Set up required tooling for creating an e2e test environment'
+
+runs:
+  using: "composite"
+  steps:
+    - name: 'Install Skaffold'
+      shell: bash
+      run: |
+        curl -Lo skaffold https://storage.googleapis.com/skaffold/releases/latest/skaffold-linux-amd64 && sudo install skaffold /usr/local/bin/ && skaffold version
+    - name: 'Install and start minikube'
+      id: minikube
+      uses: medyagh/setup-minikube@b127ace2ffdece4eb28e7dedb9da39f495ab7af0


### PR DESCRIPTION
As we are setting up e2e test environment for Verily using minikube and skaffold. Currently, a test environment setup requires setting up multiple tools, for ex: minikube, skaffold. 

Creating a reusable action which can be used by other Verily teams to directly use and simplify their github workflows. 

TESTED=Tested by pushing to a branch and referencing in an existing github workflow for verily : https://github.com/verily-src/ss-api-e2e-tests/actions/runs/3425619554/jobs/5706583793 