### PR TITLE
fix: don't close DB connection after it's established

### DIFF
--- a/mysqltest/docker.go
+++ b/mysqltest/docker.go
@@ -159,7 +159,6 @@ func tryLogin(conf *config, port string) error {
 	if err != nil {
 		return fmt.Errorf("sql.Open(): %w", err)
 	}
-	defer db.Close()
 
 	if err := db.Ping(); err != nil {
 		return fmt.Errorf("db.Ping(): %w", err)

--- a/mysqltest/docker_test.go
+++ b/mysqltest/docker_test.go
@@ -46,7 +46,6 @@ func TestKillAfter(t *testing.T) {
 		t.Fatal(err)
 	}
 	db := connect(t, ci)
-	defer db.Close()
 
 	if err := db.Ping(); err != nil {
 		t.Fatalf("db.Ping: %v", err)


### PR DESCRIPTION
The docs for DB.Close() specfically say not to do this. These connections should be long-lived. This bug may be causing problems with connection pooling, causing clients to get "bad connection" errors.