### PR TITLE
Move linter config into a file, add new linters

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -7,6 +7,10 @@ on:
         description: 'The version of Go to install and use.'
         type: 'string'
         required: true
+      golangci_url:
+        description: 'The URL to a golangci file. This is only used if no file is found in the local directory.'
+        type: 'string'
+        default: 'https://raw.githubusercontent.com/abcxyz/pkg/main/.golangci.yml'
       directory:
         description: 'Directory in which Go files reside.'
         type: 'string'
@@ -60,57 +64,36 @@ jobs:
         with:
           go-version: '${{ inputs.go_version }}'
 
+      - name: 'Lint (download default configuration)'
+        id: 'load-default-config'
+        if: ${{ hashFiles('.golangci.yml', '.golangci.yaml') == '' }}
+        run: |-
+          # Create a unique output file outside of the checkout.
+          GOLANGCI_YML="${RUNNER_TEMP}/${GITHUB_SHA:0:7}.golangci.yml"
+
+          # Download the file, passing in authentication to get a higher rate
+          # limit: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
+          curl "${{ inputs.golangci_url }}" \
+            --silent \
+            --fail \
+            --location \
+            --header "Authorization: Token ${{ github.token }}" \
+            --output "${GOLANGCI_YML}"
+
+          # Save the result to an output.
+          echo "::notice::Wrote configuration file to ${GOLANGCI_YML}"
+          echo "output-file=${GOLANGCI_YML}" >> "${GITHUB_OUTPUT}"
+
       - name: 'Lint (default configuration)'
-        if: ${{ hashFiles('.golangci.yml') == '' && hashFiles('.golangci.yaml') == '' }}
+        if: ${{ hashFiles('.golangci.yml', '.golangci.yaml') == '' }}
         uses: 'golangci/golangci-lint-action@07db5389c99593f11ad7b44463c2d4233066a9b1' # ratchet:golangci/golangci-lint-action@v3
         with:
           args: |-
-            --enable=${{ join(fromJson('[
-              "asciicheck",
-              "bidichk",
-              "bodyclose",
-              "containedctx",
-              "depguard",
-              "dogsled",
-              "errcheck",
-              "errchkjson",
-              "errname",
-              "errorlint",
-              "exhaustive",
-              "exportloopref",
-              "forcetypeassert",
-              "godot",
-              "gofumpt",
-              "goheader",
-              "goimports",
-              "gomodguard",
-              "goprintffuncname",
-              "gosec",
-              "gosimple",
-              "govet",
-              "ifshort",
-              "ineffassign",
-              "makezero",
-              "noctx",
-              "nolintlint",
-              "prealloc",
-              "predeclared",
-              "revive",
-              "sqlclosecheck",
-              "staticcheck",
-              "stylecheck",
-              "tenv",
-              "thelper",
-              "tparallel",
-              "typecheck",
-              "unconvert",
-              "unused",
-              "whitespace",
-            ]'), ',') }} --max-issues-per-linter=0 --max-same-issues=0 --timeout=5m
+            --config "${{ steps.load-default-config.outputs.output-file }}"
           working-directory: '${{ inputs.directory }}'
 
       - name: 'Lint (custom configuration)'
-        if: ${{ hashFiles('.golangci.yml') != '' && hashFiles('.golangci.yaml') != '' }}
+        if: ${{ hashFiles('.golangci.yml', '.golangci.yaml') != '' }}
         uses: 'golangci/golangci-lint-action@07db5389c99593f11ad7b44463c2d4233066a9b1' # ratchet:golangci/golangci-lint-action@v3
         with:
           working-directory: '${{ inputs.directory }}'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,141 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+run:
+  # default: '1m'
+  timeout: '5m'
+
+  # default: []
+  build-tags:
+  - 'all'
+
+  # default: []
+  skip-dirs:
+  - 'internal/pb'
+  - 'third_party'
+
+  # default: true
+  skip-dirs-use-default: false
+
+  # default: ''
+  modules-download-mode: 'readonly'
+
+  # default: false
+  allow-parallel-runners: true
+
+linters:
+  enable:
+  - 'asasalint'
+  - 'asciicheck'
+  - 'bidichk'
+  - 'bodyclose'
+  - 'containedctx'
+  - 'depguard'
+  - 'dupword'
+  - 'durationcheck'
+  - 'errcheck'
+  - 'errchkjson'
+  - 'errname'
+  - 'errorlint'
+  - 'execinquery'
+  - 'exhaustive'
+  - 'exportloopref'
+  - 'forcetypeassert'
+  - 'godot'
+  - 'gofmt'
+  - 'gofumpt'
+  - 'goheader'
+  - 'goimports'
+  - 'gomodguard'
+  - 'goprintffuncname'
+  - 'gosec'
+  - 'gosimple'
+  - 'govet'
+  - 'importas'
+  - 'ineffassign'
+  - 'loggercheck'
+  - 'makezero'
+  - 'misspell'
+  - 'noctx'
+  - 'nolintlint'
+  - 'nosprintfhostport'
+  - 'paralleltest'
+  - 'prealloc'
+  - 'predeclared'
+  - 'revive'
+  - 'rowserrcheck'
+  - 'sqlclosecheck'
+  - 'staticcheck'
+  - 'stylecheck'
+  - 'tenv'
+  - 'thelper'
+  - 'typecheck'
+  - 'unconvert'
+  - 'unused'
+  - 'whitespace'
+  - 'wrapcheck'
+
+issues:
+  # default: []
+  exclude:
+  - '^G102:' # gosec: we have to bind to all ifaces in Cloud Run services
+
+  # default: []
+  exclude-rules:
+    # Exclude test files from certain linters
+    - path: '_test.go'
+      linters:
+        - 'wrapcheck'
+
+  # default: 50
+  max-issues-per-linter: 0
+
+  # default: 3
+  max-same-issues: 0
+
+linters-settings:
+  gofumpt:
+    # default: false
+    extra-rules: true
+
+  goheader:
+    values:
+      regexp:
+        YEAR_AUTHOR: '\d{4} .*'
+        INDENTATION: '[\t\f ]{2,}'
+    # default: ""
+    template: |-
+      Copyright {{ YEAR_AUTHOR }}
+
+      Licensed under the Apache License, Version 2.0 (the "License");
+      you may not use this file except in compliance with the License.
+      You may obtain a copy of the License at
+
+      {{ INDENTATION }}http://www.apache.org/licenses/LICENSE-2.0
+
+      Unless required by applicable law or agreed to in writing, software
+      distributed under the License is distributed on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+      See the License for the specific language governing permissions and
+      limitations under the License.
+
+  wrapcheck:
+    ignoreSigRegexps:
+      - '.ErrorOrNil\('
+      - 'retry\.RetryableError\('
+      - 'status\.Error\('
+
+severity:
+  # default: ''
+  default-severity: error

--- a/grpcutil/jwt_auth.go
+++ b/grpcutil/jwt_auth.go
@@ -44,7 +44,7 @@ type JWTAuthenticationHandler struct {
 }
 
 // NewJWTAuthenticationHandler returns a JWTAuthenticationHandler with a verifier initialized. Uses defaults
-// for JWT related fields that will retreive a user email when using IAM on GCP.
+// for JWT related fields that will retrieve a user email when using IAM on GCP.
 func NewJWTAuthenticationHandler(ctx context.Context, opts ...JWTAuthOption) (*JWTAuthenticationHandler, error) {
 	j := &JWTAuthenticationHandler{
 		JWTPrefix:          "bearer ",
@@ -68,7 +68,7 @@ func NewJWTAuthenticationHandler(ctx context.Context, opts ...JWTAuthOption) (*J
 	}
 	verifier, err := jwtutil.NewVerifier(ctx, j.Endpoint)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create verifier: %w", err)
 	}
 	j.Verifier = verifier
 	return j, nil

--- a/mysqltest/docker.go
+++ b/mysqltest/docker.go
@@ -110,7 +110,7 @@ func runContainer(conf *config, pool *dockertest.Pool) (*dockertest.Resource, er
 		var extraMsg string
 		switch {
 		case strings.Contains(err.Error(), "no such file"):
-			extraMsg = `. Please install docker: 
+			extraMsg = `. Please install docker:
 		Instructions for Debian: https://docs.docker.com/engine/install/debian/
 		Instructions for Mac: https://docs.docker.com/desktop/mac/install/`
 		case strings.Contains(err.Error(), "permission denied"):

--- a/mysqltest/mysqltest_test.go
+++ b/mysqltest/mysqltest_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package mysqltest
 
 import (
@@ -48,6 +62,8 @@ func TestMustStart_NonexistentVersion(t *testing.T) {
 }
 
 func TestBuildConfig(t *testing.T) {
+	t.Parallel()
+
 	logger := &testLogger{t}
 	conf := buildConfig(
 		WithKillAfterSeconds(1),

--- a/terraform/modules/workload-identity-federation/main.tf
+++ b/terraform/modules/workload-identity-federation/main.tf
@@ -1,18 +1,17 @@
-/**
- * Copyright 2022 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+# Copyright 2022 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 resource "google_project_service" "serviceusage" {
   project            = var.project_id
   service            = "serviceusage.googleapis.com"

--- a/terraform/modules/workload-identity-federation/outputs.tf
+++ b/terraform/modules/workload-identity-federation/outputs.tf
@@ -1,18 +1,17 @@
-/**
- * Copyright 2022 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+# Copyright 2022 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 output "pool_name" {
   value = google_iam_workload_identity_pool.pool.name
 }

--- a/terraform/modules/workload-identity-federation/variables.tf
+++ b/terraform/modules/workload-identity-federation/variables.tf
@@ -1,18 +1,16 @@
-/**
- * Copyright 2022 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+# Copyright 2022 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 variable "project_id" {
   type        = string

--- a/testutil/integ_test.go
+++ b/testutil/integ_test.go
@@ -1,12 +1,25 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package testutil
 
 import (
 	"testing"
 )
 
+//nolint:paralleltest // Can't be paralleled because of t.Setenv
 func TestIsIntegration(t *testing.T) {
-	// Can't be paralleled since we set env var.
-
 	if IsIntegration(t) {
 		t.Errorf("IsIntegration() got 'true' want 'false'")
 	}

--- a/testutil/jwt.go
+++ b/testutil/jwt.go
@@ -25,7 +25,7 @@ import (
 )
 
 // CreateJWT creates a JWT for use in testing. Fills out standard claims.
-func CreateJWT(tb testing.TB, id string, email string) jwt.Token {
+func CreateJWT(tb testing.TB, id, email string) jwt.Token {
 	tb.Helper()
 
 	tok, err := jwt.NewBuilder().

--- a/worker/worker.go
+++ b/worker/worker.go
@@ -104,7 +104,7 @@ func (w *Worker[T]) Do(ctx context.Context, fn WorkFunc[T]) error {
 	}
 
 	if err := w.sem.Acquire(ctx, 1); err != nil {
-		return err
+		return fmt.Errorf("failed to acquire semaphore: %w", err)
 	}
 
 	// It's possible the worker was stopped while we were waiting for the
@@ -148,7 +148,7 @@ func (w *Worker[T]) Done(ctx context.Context) ([]*Result[T], error) {
 	}
 
 	if err := w.sem.Acquire(ctx, w.size); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to acquire semaphore: %w", err)
 	}
 	defer w.sem.Release(w.size)
 


### PR DESCRIPTION
This moves the linting configuration into a file and adds a few new linters that were released since the initial design. One of the nicest ones is goheader, which checks that the Apache license header is added to new Go files. Turns out, we had a slight typo that has been copy-pasted around, so I fixed that too.