### PR TITLE
feat: add a util to check if it's in an integration test

### DIFF
--- a/testutil/integ.go
+++ b/testutil/integ.go
@@ -18,6 +18,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"testing"
 )
 
 // IsIntegration checks env var TEST_INTEGRATION and consider that we're in an
@@ -33,4 +34,11 @@ func IsIntegration() bool {
 		return false
 	}
 	return isInteg
+}
+
+// SkipIfNotIntegration skips the test if [IsIntegration] returns false.
+func SkipIfNotIntegration(tb testing.TB) {
+	if !IsIntegration() {
+		tb.Skip("Not integration test, skipping")
+	}
 }

--- a/testutil/integ.go
+++ b/testutil/integ.go
@@ -38,6 +38,7 @@ func IsIntegration() bool {
 
 // SkipIfNotIntegration skips the test if [IsIntegration] returns false.
 func SkipIfNotIntegration(tb testing.TB) {
+	tb.Helper()
 	if !IsIntegration() {
 		tb.Skip("Not integration test, skipping")
 	}

--- a/testutil/integ.go
+++ b/testutil/integ.go
@@ -1,0 +1,36 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testutil
+
+import (
+	"log"
+	"os"
+	"strconv"
+)
+
+// IsIntegration checks env var TEST_INTEGRATION and consider that we're in an
+// integration test if it's set to true.
+func IsIntegration() bool {
+	integVal := os.Getenv("TEST_INTEGRATION")
+	if integVal == "" {
+		return false
+	}
+	isInteg, err := strconv.ParseBool(integVal)
+	if err != nil {
+		log.Printf("WARNING: failed to parse TEST_INTEGRATION; will default to 'false': %v", err)
+		return false
+	}
+	return isInteg
+}

--- a/testutil/integ.go
+++ b/testutil/integ.go
@@ -15,7 +15,6 @@
 package testutil
 
 import (
-	"log"
 	"os"
 	"strconv"
 	"testing"
@@ -23,15 +22,15 @@ import (
 
 // IsIntegration checks env var TEST_INTEGRATION and consider that we're in an
 // integration test if it's set to true.
-func IsIntegration() bool {
+func IsIntegration(tb testing.TB) bool {
+	tb.Helper()
 	integVal := os.Getenv("TEST_INTEGRATION")
 	if integVal == "" {
 		return false
 	}
 	isInteg, err := strconv.ParseBool(integVal)
 	if err != nil {
-		log.Printf("WARNING: failed to parse TEST_INTEGRATION; will default to 'false': %v", err)
-		return false
+		tb.Fatalf("failed to parse TEST_INTEGRATION: %v", err)
 	}
 	return isInteg
 }
@@ -39,7 +38,7 @@ func IsIntegration() bool {
 // SkipIfNotIntegration skips the test if [IsIntegration] returns false.
 func SkipIfNotIntegration(tb testing.TB) {
 	tb.Helper()
-	if !IsIntegration() {
+	if !IsIntegration(tb) {
 		tb.Skip("Not integration test, skipping")
 	}
 }

--- a/testutil/integ_test.go
+++ b/testutil/integ_test.go
@@ -1,7 +1,6 @@
 package testutil
 
 import (
-	"os"
 	"testing"
 )
 
@@ -12,7 +11,7 @@ func TestIsIntegration(t *testing.T) {
 		t.Errorf("IsIntegration() got 'true' want 'false'")
 	}
 
-	os.Setenv("TEST_INTEGRATION", "true")
+	t.Setenv("TEST_INTEGRATION", "true")
 	if !IsIntegration() {
 		t.Errorf("IsIntegration() got 'false' want 'true'")
 	}

--- a/testutil/integ_test.go
+++ b/testutil/integ_test.go
@@ -5,7 +5,7 @@ import (
 )
 
 func TestIsIntegration(t *testing.T) {
-	t.Parallel()
+	// Can't be paralleled since we set env var.
 
 	if IsIntegration() {
 		t.Errorf("IsIntegration() got 'true' want 'false'")

--- a/testutil/integ_test.go
+++ b/testutil/integ_test.go
@@ -7,12 +7,12 @@ import (
 func TestIsIntegration(t *testing.T) {
 	// Can't be paralleled since we set env var.
 
-	if IsIntegration() {
+	if IsIntegration(t) {
 		t.Errorf("IsIntegration() got 'true' want 'false'")
 	}
 
 	t.Setenv("TEST_INTEGRATION", "true")
-	if !IsIntegration() {
+	if !IsIntegration(t) {
 		t.Errorf("IsIntegration() got 'false' want 'true'")
 	}
 }

--- a/testutil/integ_test.go
+++ b/testutil/integ_test.go
@@ -1,0 +1,19 @@
+package testutil
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsIntegration(t *testing.T) {
+	t.Parallel()
+
+	if IsIntegration() {
+		t.Errorf("IsIntegration() got 'true' want 'false'")
+	}
+
+	os.Setenv("TEST_INTEGRATION", "true")
+	if !IsIntegration() {
+		t.Errorf("IsIntegration() got 'false' want 'true'")
+	}
+}


### PR DESCRIPTION
Use this to skip integration test in unit test so we can run test uniformly with `go test ./...`

```go
func TestMyIntegration(t *testing.T) {
  testutil.SkipIfNotIntegration()
  // Test stuff
}
```

Follow up - update lumberjack / jvs to use this to skip integration test.