### PR TITLE
fix: added more flexibility to the golang-lint regex for header.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -113,7 +113,7 @@ linters-settings:
     values:
       regexp:
         YEAR_AUTHOR: '\d{4} .*'
-        INDENTATION: '[\t\f ]{2,}'
+        INDENTATION: '[\t\f]+|[ ]{2,}'
     # default: ""
     template: |-
       Copyright {{ YEAR_AUTHOR }}


### PR DESCRIPTION
A single tab should be valid on the `// http://www.apache.org/licenses/LICENSE-2.0` line since that's what gofumpt seems to like to do. The current regex is looking for at least 2 tabs.