### PR TITLE
fix terraform lint directories

### DIFF
--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -34,7 +34,7 @@ jobs:
         shell: 'bash'
         working-directory: '${{ inputs.directory }}'
         run: |-
-          DIRS="$(find . -name '*.tf' -printf "%h " | sort -u)"
+          DIRS="$(find . -name '*.tf' -printf "%h\n" | sort -u)"
           echo "TERRAFORM_DIRS=${DIRS}" >> $GITHUB_ENV
 
       - name: 'Check formatting'


### PR DESCRIPTION
The missing `\n` was causing `sort -u` to not do the "unique" part causing duplicate runs on the same directory.