### PR TITLE
Add general purpose HTML and JSON rendering package

### DIFF
--- a/renderer/assets.go
+++ b/renderer/assets.go
@@ -1,0 +1,126 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renderer
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"encoding/base64"
+	"fmt"
+	htmltemplate "html/template"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"sync"
+	texttemplate "text/template"
+)
+
+const sriPrefix = "sha512-"
+
+var (
+	cssIncludeTmpl = texttemplate.Must(texttemplate.New(`cssIncludeTmpl`).Parse(strings.TrimSpace(`
+{{ range . -}}
+<link rel="stylesheet" href="/{{.Path}}" integrity="{{.SRI}}" crossorigin="anonymous" referrerpolicy="no-referrer" />
+{{ end }}
+`)))
+
+	cssIncludeTagCache htmltemplate.HTML
+)
+
+var (
+	jsIncludeTmpl = texttemplate.Must(texttemplate.New(`jsIncludeTmpl`).Parse(strings.TrimSpace(`
+{{ range . -}}
+<script defer src="/{{.Path}}" integrity="{{.SRI}}" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+{{ end }}
+`)))
+	jsIncludeTagCache htmltemplate.HTML
+)
+
+// asset represents a javascript or css asset.
+type asset struct {
+	// Path is the virtual path, relative to the URL root.
+	Path string
+
+	// SRI is the sha384 resource integrity.
+	SRI string
+}
+
+// assetIncludeTag searches the fs for all assets of the given search type and
+// renders the template. In non-dev mode, the results are cached on the first
+// invocation.
+func assetIncludeTag(fsys fs.FS, search string, tmpl *texttemplate.Template, cache *htmltemplate.HTML, devMode bool) func() (htmltemplate.HTML, error) {
+	var mu sync.Mutex
+
+	return func() (htmltemplate.HTML, error) {
+		if !devMode {
+			mu.Lock()
+			defer mu.Unlock()
+			if *cache != "" {
+				return *cache, nil
+			}
+		}
+
+		entries, err := fs.ReadDir(fsys, search)
+		if err != nil {
+			return "", fmt.Errorf("failed to read entries: %w", err)
+		}
+
+		list := make([]*asset, 0, len(entries))
+		for _, entry := range entries {
+			name := entry.Name()
+			pth := filepath.Join(search, name)
+
+			f, err := fsys.Open(pth)
+			if err != nil {
+				return "", fmt.Errorf("failed to open %s: %w", name, err)
+			}
+
+			integrity, err := generateSRI(f)
+			if err != nil {
+				return "", fmt.Errorf("failed to generate SRI for %s: %w", name, err)
+			}
+
+			list = append(list, &asset{
+				Path: pth,
+				SRI:  integrity,
+			})
+		}
+
+		var b bytes.Buffer
+		if err := tmpl.Execute(&b, list); err != nil {
+			return "", fmt.Errorf("failed to render %s asset: %w", search, err)
+		}
+		result := htmltemplate.HTML(b.String()) //nolint:gosec // No user-supplied input
+
+		if !devMode {
+			*cache = result
+		}
+
+		return result, nil
+	}
+}
+
+// generateSRI is a helper that generates an SRI from the given reader. It
+// closes the given reader.
+func generateSRI(r io.ReadCloser) (string, error) {
+	defer r.Close()
+
+	h := sha512.New()
+	if _, err := io.Copy(h, r); err != nil {
+		return "", fmt.Errorf("failed to generate sri hash: %w", err)
+	}
+	return sriPrefix + base64.RawStdEncoding.EncodeToString(h.Sum(nil)), nil
+}

--- a/renderer/assets_test.go
+++ b/renderer/assets_test.go
@@ -1,0 +1,91 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renderer
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestAssetIncludeTag(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	sys := fstest.MapFS{
+		"static/css/index.css": &fstest.MapFile{
+			Data: []byte(`
+				body {
+					background: '#000';
+				}
+			`),
+		},
+		"static/js/index.js": &fstest.MapFile{
+			Data: []byte(`
+				alert('hi');
+			`),
+		},
+		"template.html": &fstest.MapFile{
+			Data: []byte(`
+				{{ define "template" }}
+					{{ cssIncludeTag }}
+					{{ jsIncludeTag }}
+				{{ end }}
+			`),
+		},
+	}
+
+	r, err := New(ctx, sys, WithDebug(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		tmpl string
+		exp  string
+	}{
+		{
+			name: "css",
+			tmpl: "template",
+			exp:  `<link rel="stylesheet" href="/static/css/index.css" integrity="sha512-CZ/ju4L53fGRLdwSN7Cl0QyO336hYAIgXyASelQXWHb354JD9u+MBMEgFtCjKuFzQ84MYzBHcOzPEqK/roRvYA" crossorigin="anonymous" referrerpolicy="no-referrer" />`,
+		},
+		{
+			name: "js",
+			tmpl: "template",
+			exp:  `<script defer src="/static/js/index.js" integrity="sha512-DFr7R1UkHXJDzmXpnOEq+oYqK4oj/4aCo4zeWnWXo5DkAV2TNwNlrGM4J8nEYwTCFcXwwshSgaSqN8UFv6wZ6w" crossorigin="anonymous" referrerpolicy="no-referrer"></script>`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			w := httptest.NewRecorder()
+
+			r.RenderHTMLStatus(w, 200, tc.tmpl, nil)
+			w.Flush()
+
+			if got, want := w.Body.String(), tc.exp; !strings.Contains(got, want) {
+				t.Errorf("expected\n\n%s\n\nto contain %q", got, want)
+			}
+		})
+	}
+}

--- a/renderer/funcs.go
+++ b/renderer/funcs.go
@@ -1,0 +1,188 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renderer
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"html/template"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+func builtinFuncs() template.FuncMap {
+	return map[string]any{
+		"joinStrings":    joinStrings,
+		"toSentence":     toSentence,
+		"trimSpace":      trimSpace,
+		"stringContains": strings.Contains,
+		"toLower":        strings.ToLower,
+		"toUpper":        strings.ToUpper,
+		"toJSON":         json.Marshal,
+		"toBase64":       base64.StdEncoding.EncodeToString,
+		"toPercent":      toPercent,
+		"safeHTML":       safeHTML,
+		"checkedIf":      valueIfTruthy("checked"),
+		"requiredIf":     valueIfTruthy("required"),
+		"selectedIf":     valueIfTruthy("selected"),
+		"readonlyIf":     valueIfTruthy("readonly"),
+		"disabledIf":     valueIfTruthy("disabled"),
+		"invalidIf":      valueIfTruthy("is-invalid"),
+
+		"pathEscape":    url.PathEscape,
+		"pathUnescape":  url.PathUnescape,
+		"queryEscape":   url.QueryEscape,
+		"queryUnescape": url.QueryUnescape,
+	}
+}
+
+// safeHTML un-escapes known safe html.
+func safeHTML(s string) template.HTML {
+	return template.HTML(s) //nolint:gosec // Requires users to explicitly invoke
+}
+
+// toStringSlice converts the input slice to strings. The values must be
+// primitive or implement the fmt.Stringer interface.
+func toStringSlice(i any) ([]string, error) {
+	if i == nil {
+		return nil, nil
+	}
+
+	t := reflect.TypeOf(i)
+	for t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	if t.Kind() != reflect.Slice && t.Kind() != reflect.Array {
+		return nil, fmt.Errorf("value is not a slice: %T", i)
+	}
+
+	s := reflect.ValueOf(i)
+	for s.Kind() == reflect.Ptr {
+		s = s.Elem()
+	}
+
+	l := make([]string, 0, s.Len())
+	for i := 0; i < s.Len(); i++ {
+		val := s.Index(i)
+		for val.Kind() == reflect.Ptr {
+			val = val.Elem()
+		}
+
+		switch t := val.Interface().(type) {
+		case fmt.Stringer:
+			l = append(l, t.String())
+		case error:
+			l = append(l, t.Error())
+		case string:
+			l = append(l, t)
+		case int:
+			l = append(l, strconv.FormatInt(int64(t), 10))
+		case int8:
+			l = append(l, strconv.FormatInt(int64(t), 10))
+		case int16:
+			l = append(l, strconv.FormatInt(int64(t), 10))
+		case int32:
+			l = append(l, strconv.FormatInt(int64(t), 10))
+		case int64:
+			l = append(l, strconv.FormatInt(t, 10))
+		case uint:
+			l = append(l, strconv.FormatUint(uint64(t), 10))
+		case uint8:
+			l = append(l, strconv.FormatUint(uint64(t), 10))
+		case uint16:
+			l = append(l, strconv.FormatUint(uint64(t), 10))
+		case uint32:
+			l = append(l, strconv.FormatUint(uint64(t), 10))
+		case uint64:
+			l = append(l, strconv.FormatUint(t, 10))
+		}
+	}
+
+	return l, nil
+}
+
+// joinStrings joins a list of strings or string-like things.
+func joinStrings(i any, sep string) (string, error) {
+	l, err := toStringSlice(i)
+	if err != nil {
+		return "", nil
+	}
+	return strings.Join(l, sep), nil
+}
+
+// toSentence joins a list of string like things into a human-friendly sentence.
+func toSentence(i any, joiner string) (string, error) {
+	l, err := toStringSlice(i)
+	if err != nil {
+		return "", nil
+	}
+
+	switch len(l) {
+	case 0:
+		return "", nil
+	case 1:
+		return l[0], nil
+	case 2:
+		return l[0] + " " + joiner + " " + l[1], nil
+	default:
+		parts, last := l[0:len(l)-1], l[len(l)-1]
+		return strings.Join(parts, ", ") + ", " + joiner + " " + last, nil
+	}
+}
+
+func valueIfTruthy(s string) func(i any) template.HTMLAttr {
+	return func(i any) template.HTMLAttr {
+		if i == nil {
+			return ""
+		}
+
+		v := reflect.ValueOf(i)
+		if !v.IsValid() {
+			return ""
+		}
+
+		//nolint:exhaustive
+		switch v.Kind() {
+		case reflect.Bool:
+			if v.Bool() {
+				return template.HTMLAttr(s) //nolint:gosec // Booleans are "true" or "false"
+			}
+		case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+			if v.Len() > 0 {
+				return template.HTMLAttr(s) //nolint:gosec // Trusted source
+			}
+		default:
+		}
+
+		return ""
+	}
+}
+
+// toPercent takes the given float, multiplies by 100, and then appends a
+// trailing percent symbol.
+func toPercent(f float64) string {
+	return fmt.Sprintf("%.2f%%", f*100.0)
+}
+
+// trimSpace trims space and "zero-width no-break space".
+func trimSpace(s string) string {
+	return strings.TrimFunc(s, func(r rune) bool {
+		return unicode.IsSpace(r) || !unicode.IsPrint(r) || r == '\uFEFF'
+	})
+}

--- a/renderer/funcs_test.go
+++ b/renderer/funcs_test.go
@@ -1,0 +1,303 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renderer
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/abcxyz/pkg/testutil"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestToStringSlice(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   any
+		exp  []string
+		err  string
+	}{
+		{
+			name: "nil",
+			in:   nil,
+			exp:  nil,
+		},
+		{
+			name: "not_slice",
+			in:   3,
+			err:  "value is not a slice",
+		},
+		{
+			name: "pointers",
+			in:   []*int{ptrTo(2), ptrTo(3), ptrTo(4)},
+			exp:  []string{"2", "3", "4"},
+		},
+		{
+			name: "stringer",
+			in:   []time.Duration{10 * time.Second, 20 * time.Hour},
+			exp:  []string{"10s", "20h0m0s"},
+		},
+		{
+			name: "error",
+			in:   []error{fmt.Errorf("one"), fmt.Errorf("two")},
+			exp:  []string{"one", "two"},
+		},
+		{
+			name: "string",
+			in:   []string{"one", "two"},
+			exp:  []string{"one", "two"},
+		},
+		{
+			name: "int",
+			in:   []int{1, 2},
+			exp:  []string{"1", "2"},
+		},
+		{
+			name: "int8",
+			in:   []int8{1, 2},
+			exp:  []string{"1", "2"},
+		},
+		{
+			name: "int16",
+			in:   []int16{1, 2},
+			exp:  []string{"1", "2"},
+		},
+		{
+			name: "int32",
+			in:   []int32{1, 2},
+			exp:  []string{"1", "2"},
+		},
+		{
+			name: "int64",
+			in:   []int64{1, 2},
+			exp:  []string{"1", "2"},
+		},
+		{
+			name: "uint",
+			in:   []uint{1, 2},
+			exp:  []string{"1", "2"},
+		},
+		{
+			name: "uint8",
+			in:   []uint8{1, 2},
+			exp:  []string{"1", "2"},
+		},
+		{
+			name: "uint16",
+			in:   []uint16{1, 2},
+			exp:  []string{"1", "2"},
+		},
+		{
+			name: "uint32",
+			in:   []uint32{1, 2},
+			exp:  []string{"1", "2"},
+		},
+		{
+			name: "uint64",
+			in:   []uint64{1, 2},
+			exp:  []string{"1", "2"},
+		},
+		{
+			name: "mixed",
+			in:   []any{5, 10 * time.Second, fmt.Errorf("hello"), "world"},
+			exp:  []string{"5", "10s", "hello", "world"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			list, err := toStringSlice(tc.in)
+			if diff := testutil.DiffErrString(err, tc.err); diff != "" {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(list, tc.exp); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestJoinStrings(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   any
+		exp  string
+	}{
+		{
+			name: "nil",
+			in:   nil,
+			exp:  "",
+		},
+		{
+			name: "single",
+			in:   []string{"a"},
+			exp:  "a",
+		},
+		{
+			name: "multi",
+			in:   []string{"a", "b", "c"},
+			exp:  "a,b,c",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := joinStrings(tc.in, ",")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(result, tc.exp); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestToSentence(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   any
+		exp  string
+	}{
+		{
+			name: "nil",
+			in:   nil,
+			exp:  "",
+		},
+		{
+			name: "single",
+			in:   []string{"a"},
+			exp:  "a",
+		},
+		{
+			name: "double",
+			in:   []string{"a", "b"},
+			exp:  "a and b",
+		},
+		{
+			name: "multi",
+			in:   []string{"a", "b", "c"},
+			exp:  "a, b, and c",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := toSentence(tc.in, "and")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(result, tc.exp); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestToPercent(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   float64
+		exp  string
+	}{
+		{
+			name: "zero",
+			in:   0,
+			exp:  "0.00%",
+		},
+		{
+			name: "long",
+			in:   3.14159,
+			exp:  "314.16%",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := toPercent(tc.in)
+			if diff := cmp.Diff(result, tc.exp); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestTrimSpace(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		exp  string
+	}{
+		{
+			name: "empty",
+			in:   "",
+			exp:  "",
+		},
+		{
+			name: "unicode",
+			in:   "val12!\uFEFF",
+			exp:  "val12!",
+		},
+		{
+			name: "unicode",
+			in:   " val12!  \r\t",
+			exp:  "val12!",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result := trimSpace(tc.in)
+			if diff := cmp.Diff(result, tc.exp); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func ptrTo[T any](in T) *T {
+	return &in
+}

--- a/renderer/html.go
+++ b/renderer/html.go
@@ -1,0 +1,100 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renderer
+
+import (
+	"bytes"
+	"fmt"
+	"html"
+	"net/http"
+)
+
+// RenderHTML calls RenderHTMLStatus with a http.StatusOK (200).
+func (r *Renderer) RenderHTML(w http.ResponseWriter, tmpl string, data any) {
+	r.RenderHTMLStatus(w, http.StatusOK, tmpl, data)
+}
+
+// RenderHTMLStatus renders the given HTML template by name. It attempts to
+// gracefully handle any rendering errors to avoid partial responses sent to the
+// response by writing to a buffer first, then flushing the buffer to the
+// response.
+//
+// If template rendering fails, a generic 500 page is returned. In dev mode, the
+// error is included on the page. If flushing the buffer to the response fails,
+// an error is logged, but no recovery is attempted.
+//
+// The buffers are fetched via a sync.Pool to reduce allocations and improve
+// performance.
+func (r *Renderer) RenderHTMLStatus(w http.ResponseWriter, code int, tmpl string, data any) {
+	if r.debug {
+		if err := r.loadTemplates(); err != nil {
+			r.onError(fmt.Errorf("failed to reload templates in renderer: %w", err))
+
+			msg := html.EscapeString(err.Error())
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(w, htmlErrTmpl, msg)
+			return
+		}
+	}
+
+	// Acquire a renderer.
+	b, ok := r.rendererPool.Get().(*bytes.Buffer)
+	if !ok {
+		panic("rendererPool is not a *bytes.Buffer")
+	}
+	b.Reset()
+	defer r.rendererPool.Put(b)
+
+	// Render into the renderer.
+	if err := r.executeTemplate(b, tmpl, data); err != nil {
+		r.onError(fmt.Errorf("failed to execute template: %w", err))
+
+		msg := "An internal error occurred."
+		if r.debug {
+			msg = err.Error()
+		}
+		msg = html.EscapeString(msg)
+
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, htmlErrTmpl, msg)
+		return
+	}
+
+	// Rendering worked, flush to the response.
+	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+	w.WriteHeader(code)
+	if _, err := b.WriteTo(w); err != nil {
+		// We couldn't write the buffer. We can't change the response header or
+		// content type if we got this far, so the best option we have is to log the
+		// error.
+		r.onError(fmt.Errorf("failed to write html response: %w", err))
+	}
+}
+
+// htmlErrTmpl is the template to use when returning an HTML error. It is
+// rendered using Printf, not html/template, so values must be escaped by the
+// caller.
+const htmlErrTmpl = `
+<html>
+  <head>
+    <title>Internal server error</title>
+  </head>
+
+  <body>
+    <h1>Internal server error</h1>
+    <p style="font-family:monospace">%s</p>
+  </body>
+</html>
+`

--- a/renderer/html_test.go
+++ b/renderer/html_test.go
@@ -1,0 +1,79 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renderer
+
+import (
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestRenderHTMLStatus(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	sys := fstest.MapFS{
+		"template.html": &fstest.MapFile{
+			Data: []byte(`
+				{{ define "template" }}
+					Hello World!
+				{{ end }}
+			`),
+			Mode: 0o600,
+		},
+	}
+
+	r, err := New(ctx, sys, WithDebug(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name string
+		tmpl string
+		exp  string
+	}{
+		{
+			name: "no_template",
+			tmpl: "non_existenxt",
+			exp:  "&#34;non_existenxt&#34; is undefined",
+		},
+		{
+			name: "success",
+			tmpl: "template",
+			exp:  "Hello World!",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			w := httptest.NewRecorder()
+
+			r.RenderHTMLStatus(w, 200, tc.tmpl, nil)
+			w.Flush()
+
+			if got, want := w.Body.String(), tc.exp; !strings.Contains(got, want) {
+				t.Errorf("expected\n\n%s\n\nto contain %q", got, want)
+			}
+		})
+	}
+}

--- a/renderer/json.go
+++ b/renderer/json.go
@@ -1,0 +1,138 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renderer
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// RenderJSON renders the interface as JSON. It attempts to gracefully handle
+// any rendering errors to avoid partial responses sent to the response by
+// writing to a buffer first, then flushing the buffer to the response.
+//
+// If the provided data is nil and the response code is a 200, the result will
+// be `{"ok":true}`. If the code is not a 200, the response will be of the
+// format `{"error":"<val>"}` where val is the JSON-escaped http.StatusText for
+// the provided code.
+//
+// If rendering fails, a generic 500 JSON response is returned. In dev mode, the
+// error is included in the payload. If flushing the buffer to the response
+// fails, an error is logged, but no recovery is attempted.
+//
+// The buffers are fetched via a sync.Pool to reduce allocations and improve
+// performance.
+func (r *Renderer) RenderJSON(w http.ResponseWriter, code int, data any) {
+	// Avoid marshaling nil data.
+	if data == nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
+
+		// Return an OK response.
+		if code >= http.StatusOK && code < http.StatusMultipleChoices {
+			fmt.Fprint(w, jsonOKResp)
+			return
+		}
+
+		// Return an error with the generic HTTP text as the error.
+		msg := escapeJSON(http.StatusText(code))
+		fmt.Fprintf(w, jsonErrTmpl, msg)
+		return
+	}
+
+	// Special-case errors.
+	switch typ := data.(type) {
+	case (interface {
+		// Go 1.20 error join
+		Unwrap() []error
+	}):
+		data = newMultiError(typ.Unwrap()...)
+	case (interface {
+		// hashicorp/go-multierror
+		WrappedErrors() []error
+	}):
+		data = newMultiError(typ.WrappedErrors()...)
+	case []error:
+		data = newMultiError(typ...)
+	case error:
+		data = newMultiError(typ)
+	}
+
+	// Acquire a renderer.
+	b, ok := r.rendererPool.Get().(*bytes.Buffer)
+	if !ok {
+		panic("rendererPool is not a *bytes.Buffer")
+	}
+	b.Reset()
+	defer r.rendererPool.Put(b)
+
+	// Render into the renderer.
+	if err := json.NewEncoder(b).Encode(data); err != nil {
+		r.onError(fmt.Errorf("failed to marshal json: %w", err))
+
+		msg := "An internal error occurred."
+		if r.debug {
+			msg = err.Error()
+		}
+		msg = escapeJSON(msg)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, jsonErrTmpl, msg)
+		return
+	}
+
+	// Rendering worked, flush to the response.
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	if _, err := b.WriteTo(w); err != nil {
+		// We couldn't write the buffer. We can't change the response header or
+		// content type if we got this far, so the best option we have is to log the
+		// error.
+		r.onError(fmt.Errorf("failed to write json response: %w", err))
+	}
+}
+
+// escapeJSON does primitive JSON escaping.
+func escapeJSON(s string) string {
+	return strings.ReplaceAll(s, `"`, `\"`)
+}
+
+// jsonErrTmpl is the template to use when returning a JSON error. It is
+// rendered using Printf, not json.Encode, so values must be escaped by the
+// caller.
+const jsonErrTmpl = `{"errors":["%s"]}`
+
+// jsonOKResp is the return value for empty data responses.
+const jsonOKResp = `{"ok":true}`
+
+type multiError struct {
+	Errors []string `json:"errors,omitempty"`
+}
+
+// newMultiError constructs a multierror from the given errors. Any nil errors
+// are discarded. Errors are added in the order in which they are given.
+func newMultiError(errs ...error) *multiError {
+	msgs := make([]string, 0, len(errs))
+	for _, err := range errs {
+		if err != nil {
+			msgs = append(msgs, err.Error())
+		}
+	}
+	return &multiError{Errors: msgs}
+}

--- a/renderer/json_test.go
+++ b/renderer/json_test.go
@@ -1,0 +1,130 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renderer
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRenderJSON(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	// cycled exists to force a JSON cycle to test error handling.
+	type cycled struct {
+		Next *cycled `json:"next,omitempty"`
+	}
+
+	cycle := &cycled{}
+	cycle.Next = cycle
+
+	cases := []struct {
+		name  string
+		code  int
+		in    any
+		debug bool
+		exp   string
+	}{
+		{
+			name: "nil_200",
+			code: 200,
+			in:   nil,
+			exp:  `{"ok":true}`,
+		},
+		{
+			name: "nil_403",
+			code: 403,
+			in:   nil,
+			exp:  `{"errors":["Forbidden"]}`,
+		},
+		{
+			name: "joined_error",
+			code: 400,
+			in:   errors.Join(fmt.Errorf("one"), fmt.Errorf("two")),
+			exp:  `{"errors":["one","two"]}`,
+		},
+		{
+			name: "error_slice",
+			code: 400,
+			in:   []error{fmt.Errorf("one"), fmt.Errorf("two")},
+			exp:  `{"errors":["one","two"]}`,
+		},
+		{
+			name: "error",
+			code: 400,
+			in:   []error{fmt.Errorf("one")},
+			exp:  `{"errors":["one"]}`,
+		},
+		{
+			name: "complex_structure",
+			code: 200,
+			in: map[string]any{
+				"foo": []string{
+					"one",
+					"two",
+				},
+			},
+			exp: `{"foo":["one","two"]}`,
+		},
+		{
+			name: "json_cycle",
+			code: 500,
+			in:   cycle,
+			exp:  `{"errors":["An internal error occurred."]}`,
+		},
+		{
+			name:  "json_cycle_debug",
+			code:  500,
+			in:    cycle,
+			debug: true,
+			exp:   `{"errors":["json: unsupported value: encountered a cycle via *renderer.cycled"]}`,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			w := httptest.NewRecorder()
+
+			r, err := New(ctx, nil, WithDebug(tc.debug))
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			r.RenderJSON(w, tc.code, tc.in)
+			w.Flush()
+
+			if got, want := w.Header().Get("Content-Type"), "application/json"; got != want {
+				t.Errorf("expected %q to be %q", got, want)
+			}
+			if got, want := w.Code, tc.code; got != want {
+				t.Errorf("expected %d to be %d", got, want)
+			}
+
+			if got, want := strings.TrimSpace(w.Body.String()), tc.exp; got != want {
+				t.Errorf("expected %q to be %q", got, want)
+			}
+		})
+	}
+}

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -26,7 +26,7 @@
 //
 //	func AssetsFS() fs.FS {
 //	  // In dev, just read directly from disk
-//	  if v, _ := strconv.ParseBool(os.Getenv("DEV_NODE")); v {
+//	  if v, _ := strconv.ParseBool(os.Getenv("DEV_MODE")); v {
 //	    return os.DirFS("./assets")
 //	  }
 //
@@ -71,9 +71,8 @@ type Renderer struct {
 	// prevent partial responses being sent to clients.
 	rendererPool *sync.Pool
 
-	// templates is the actually collection of templates. templatesLoader is a
-	// function for (re)loading templates. templatesLock is a mutex to prevent
-	// concurrent modification of the templates field.
+	// templates is the actual collection of templates. templatesLock is a mutex
+	// to prevent concurrent modification of the templates field.
 	templates     *template.Template
 	templatesLock sync.RWMutex
 
@@ -115,7 +114,7 @@ func WithOnError(fn func(err error)) Option {
 }
 
 // WithTemplateFuncs registers additional template functions. The renderer
-// includes many helpful functions, but some applications may which to
+// includes many helpful functions, but some applications may wish to
 // inject/define their own template helpers. Functions in this map take
 // precedence over the built-in list.
 func WithTemplateFuncs(fns template.FuncMap) Option {

--- a/renderer/renderer.go
+++ b/renderer/renderer.go
@@ -1,0 +1,238 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package render exposes high-performance HTML and JSON rendering
+// functionality. Most use cases can use the [Renderer] without modification.
+// More advanced use cases can customize template functions and error handling.
+//
+// The renderer accepts a filesystem ([fs.FS]). In most cases, this will be a
+// filesystem on disk. However, it accepts the FS interface for testing and
+// [embed] purposes. Because embed does not perform hot reloading, you may want
+// to use a different fs for development versus production:
+//
+//	//go:embed assets assets/**/*
+//	var _assetsFS embed.FS
+//
+//	func AssetsFS() fs.FS {
+//	  // In dev, just read directly from disk
+//	  if v, _ := strconv.ParseBool(os.Getenv("DEV_NODE")); v {
+//	    return os.DirFS("./assets")
+//	  }
+//
+//	  // Otherwise use the embedded fs
+//	  return _assetsFS
+//	}
+//
+// The the renderer includes some prebuilt functions, including static asset
+// parsing for CSS and Javascript files. The renderer assumes these files exist
+// in a `static/css` and `static/js` directory at the root of the provided
+// filesystem.
+//
+//	assets/
+//	  \_ static/
+//	    \_ css/
+//	    \_ js/
+//
+// To render the include tags in a template:
+//
+//	{{ define "home" }}
+//	  {{ cssIncludeTag }}
+//	  {{ jsIncludeTag }}
+//	{{ end }}
+package renderer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"html/template"
+	"io"
+	"io/fs"
+	"strings"
+	"sync"
+)
+
+// Renderer is responsible for rendering various content and templates like HTML
+// and JSON responses. This implementation caches templates and uses a pool of
+// buffers.
+type Renderer struct {
+	// rendererPool is a pool of *bytes.Buffer, used as a rendering buffer to
+	// prevent partial responses being sent to clients.
+	rendererPool *sync.Pool
+
+	// templates is the actually collection of templates. templatesLoader is a
+	// function for (re)loading templates. templatesLock is a mutex to prevent
+	// concurrent modification of the templates field.
+	templates     *template.Template
+	templatesLock sync.RWMutex
+
+	// fs is the underlying filesystem to read.
+	fs fs.FS
+
+	// debug indicates templates should be reloaded on each invocation and real
+	// error responses should be rendered. Do not enable in production.
+	debug bool
+
+	// onError is a function that is called when irrecoverable errors are
+	// encountered. This is guaranteed to be non-nil when calling [New].
+	onError func(err error)
+
+	// templateFuncs is the compiled list of template functions.
+	templateFuncs template.FuncMap
+}
+
+// Option is an interface for options to creating a renderer.
+type Option func(*Renderer) *Renderer
+
+// WithDebug configures debugging on the renderer.
+func WithDebug(v bool) Option {
+	return func(r *Renderer) *Renderer {
+		r.debug = v
+		return r
+	}
+}
+
+// WithOnError overwrites the onError handler with the given function. This
+// handler is invoked when an irrecoverable error occurs while rendering, but
+// information cannot be sent back to the client. For example, if HTTP rendering
+// fails after a partial response has been sent.
+func WithOnError(fn func(err error)) Option {
+	return func(r *Renderer) *Renderer {
+		r.onError = fn
+		return r
+	}
+}
+
+// WithTemplateFuncs registers additional template functions. The renderer
+// includes many helpful functions, but some applications may which to
+// inject/define their own template helpers. Functions in this map take
+// precedence over the built-in list.
+func WithTemplateFuncs(fns template.FuncMap) Option {
+	return func(r *Renderer) *Renderer {
+		r.templateFuncs = fns
+		return r
+	}
+}
+
+// New creates a new renderer with the given details.
+func New(ctx context.Context, fsys fs.FS, opts ...Option) (*Renderer, error) {
+	r := &Renderer{
+		rendererPool: &sync.Pool{
+			New: func() interface{} {
+				return bytes.NewBuffer(make([]byte, 0, 1024))
+			},
+		},
+		fs: fsys,
+	}
+
+	for _, opt := range opts {
+		if opt != nil {
+			r = opt(r)
+		}
+	}
+
+	// Ensure there's an error handler so we don't have to nil-check each time.
+	if r.onError == nil {
+		r.onError = func(err error) {}
+	}
+
+	// Wrap the error function to recover from panics.
+	origOnError := r.onError
+	r.onError = func(err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				// do nothing
+				_ = r
+			}
+		}()
+		origOnError(err)
+	}
+
+	// Compile template functions.
+	fns := builtinFuncs()
+	fns["cssIncludeTag"] = assetIncludeTag(r.fs, "static/css", cssIncludeTmpl, &cssIncludeTagCache, r.debug)
+	fns["jsIncludeTag"] = assetIncludeTag(r.fs, "static/js", jsIncludeTmpl, &jsIncludeTagCache, r.debug)
+	for k, v := range r.templateFuncs {
+		fns[k] = v
+	}
+	r.templateFuncs = fns
+
+	// Load initial templates
+	if err := r.loadTemplates(); err != nil {
+		return nil, err
+	}
+
+	return r, nil
+}
+
+// executeTemplate executes a single HTML template with the provided data.
+func (r *Renderer) executeTemplate(w io.Writer, name string, data interface{}) error {
+	r.templatesLock.RLock()
+	defer r.templatesLock.RUnlock()
+
+	if r.templates == nil {
+		return fmt.Errorf("no html templates are defined")
+	}
+
+	return r.templates.ExecuteTemplate(w, name, data) //nolint:wrapcheck // There's no additional context we can add
+}
+
+// loadTemplates loads or reloads all templates.
+func (r *Renderer) loadTemplates() error {
+	r.templatesLock.Lock()
+	defer r.templatesLock.Unlock()
+
+	if r.fs == nil {
+		return nil
+	}
+
+	htmltmpl := template.New("").
+		Option("missingkey=zero").
+		Funcs(r.templateFuncs)
+
+	if err := loadTemplates(r.fs, htmltmpl); err != nil {
+		return fmt.Errorf("failed to load templates: %w", err)
+	}
+
+	r.templates = htmltmpl
+	return nil
+}
+
+func loadTemplates(fsys fs.FS, tmpl *template.Template) error {
+	// You might be thinking to yourself, wait, why don't you just use
+	// template.ParseFS(fsys, "**/*.html"). Well, still as of Go 1.16, glob
+	// doesn't support shopt globbing, so you still have to walk the entire
+	// filepath.
+	if err := fs.WalkDir(fsys, ".", func(pth string, info fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if info.IsDir() {
+			return nil
+		}
+
+		if strings.HasSuffix(info.Name(), ".html") {
+			if _, err := tmpl.ParseFS(fsys, pth); err != nil {
+				return fmt.Errorf("failed to parse %s: %w", pth, err)
+			}
+		}
+
+		return nil
+	}); err != nil {
+		return fmt.Errorf("failed to walk filesystem for templates: %w", err)
+	}
+
+	return nil
+}

--- a/renderer/renderer_test.go
+++ b/renderer/renderer_test.go
@@ -1,0 +1,99 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package renderer_test
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"testing/fstest"
+	"time"
+
+	"github.com/abcxyz/pkg/renderer"
+)
+
+type Server struct {
+	db map[string]any
+	h  *renderer.Renderer
+}
+
+func NewServer(ctx context.Context) *Server {
+	// Normally this would come from the filesystem, but to make the test fit in a
+	// single file...
+	fsys := fstest.MapFS{
+		"users/index.html": &fstest.MapFile{
+			Data: []byte(`
+				{{ define "users/index" }}
+					<ul>
+						{{ range .Users }}
+							<li>{{ . | toUpper }}</li>
+						{{ end }}
+					</ul>
+				{{ end }}
+			`),
+			Mode: 0o600,
+		},
+	}
+
+	h, err := renderer.New(ctx, fsys, renderer.WithDebug(true))
+	if err != nil {
+		panic(err)
+	}
+
+	return &Server{
+		db: make(map[string]any),
+		h:  h,
+	}
+}
+
+func (s *Server) Routes() http.Handler {
+	mux := http.NewServeMux()
+	mux.Handle("/users.html", s.HandleUsersIndex())
+	mux.Handle("/users.json", s.HandleUsersAPI())
+	return mux
+}
+
+func (s *Server) HandleUsersIndex() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.h.RenderHTML(w, "users/index", s.users())
+	})
+}
+
+func (s *Server) HandleUsersAPI() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.h.RenderJSON(w, 200, s.users())
+	})
+}
+
+func (s *Server) users() []string {
+	users := make([]string, 0, len(s.db))
+	for k := range s.db {
+		users = append(users, k)
+	}
+	sort.Strings(users)
+	return users
+}
+
+func Example() {
+	s := NewServer(context.Background())
+
+	srv := &http.Server{
+		Addr:    ":8080",
+		Handler: s.Routes(),
+
+		ReadHeaderTimeout: 2 * time.Second,
+	}
+	_ = srv.ListenAndServe()
+}


### PR DESCRIPTION
This brings over a bunch of the high-performance and highly-fault-tolerant HTML and JSON rendering from Exposure Notifications, but decouples it from the EN internals. Of note:

- It does not have a dependency on a specific logger and instead allows providing an `onError` handler; there are no dependencies besides the stdlib.
- Reasonable set of built-in functions with the ability to append custom ones.

The package-level comment provides more details and there are some examples of how the package can be used in renderer_test.go.