### PR TITLE
fix: closes #83 issue with comments at end of identity tokens

### DIFF
--- a/internal/tools/terraformlinter/terraform_linter.go
+++ b/internal/tools/terraformlinter/terraform_linter.go
@@ -214,7 +214,8 @@ func validateBlock(tokens hclsyntax.Tokens) []*ViolationInstance {
 			var t hclsyntax.Token
 			skipping := true
 			depth := 0
-			for skipping {
+			// while there are tokens to skip and we haven't exceeded the length of the slice
+			for skipping && len(tokens) > 1 {
 				t, tokens = tokens[0], tokens[1:]
 				if t.Type == hclsyntax.TokenOBrace || t.Type == hclsyntax.TokenOBrack {
 					depth = depth + 1
@@ -222,7 +223,7 @@ func validateBlock(tokens hclsyntax.Tokens) []*ViolationInstance {
 				if t.Type == hclsyntax.TokenCBrace || t.Type == hclsyntax.TokenCBrack {
 					depth = depth - 1
 				}
-				if depth == 0 && t.Type == hclsyntax.TokenNewline {
+				if depth == 0 && (t.Type == hclsyntax.TokenNewline || t.Type == hclsyntax.TokenComment) {
 					// Check for an extra newline
 					trailingNewline := false
 					if len(tokens) > 0 && tokens[0].Type == hclsyntax.TokenNewline {

--- a/internal/tools/terraformlinter/terraform_linter_test.go
+++ b/internal/tools/terraformlinter/terraform_linter_test.go
@@ -556,6 +556,19 @@ func TestTerraformLinter_FindViolations(t *testing.T) {
 			},
 			wantError: false,
 		},
+		// Terraform AST treats comments on a line differently than any other token.
+		// Comments absorb the newline character instead of treating it as a separate token.
+		// This requires us to check for either a true newline token or a comment token
+		// that we can treat as the end of the line.
+		{
+			name: "repro_panic_on_comment_at_end_of_line",
+			content: `
+				resource "a" "b" {
+					c = var.d # e
+				}
+			`,
+			wantError: false,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Changed the logic for detecting the end of a line to include comment tokens which greedily eat the newline token.