### PR TITLE
add want-lgtm-all reusable workflow

### DIFF
--- a/.github/workflows/want-lgtm-all.yml
+++ b/.github/workflows/want-lgtm-all.yml
@@ -1,0 +1,165 @@
+name: 'want-lgtm-all'
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+      - review_requested
+      - review_request_removed
+  pull_request_review:
+    types:
+      - submitted
+      - dismissed
+      - edited
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+permissions:
+  actions: 'write'
+  pull-requests: 'read'
+
+jobs:
+  validate:
+    runs-on: 'ubuntu-latest'
+    steps:
+      - id: 'validate-event'
+        name: 'Validate GitHub Event'
+        uses: 'actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410' # ratchet:actions/github-script@v6
+        with:
+          script: |-
+            // validate required event names
+            if (!["pull_request", "pull_request_review"].includes(context.eventName)) {
+              core.setFailed(
+                "want-lgtm-all only supports the pull_request and pull_request_review event triggers. Please modify your workflow and try again."
+              );
+              return;
+            }
+
+      - id: 'want-lgtm'
+        name: 'Validate PR Body'
+        uses: 'actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410' # ratchet:actions/github-script@v6
+        with:
+          result-encoding: 'string'
+          script: |-
+            const body = context.payload.pull_request.body || "";
+
+            // if PR body does not contain want_lgtm_all, exit gracefully
+            if (!body.match(/want_lgtm_all/gim)) {
+              core.info("PR body does not contain want_lgtm_all");
+              return "false";
+            }
+
+            return "true";
+
+      - id: 'validate-reviews'
+        name: 'Validate Reviews'
+        if: ${{ steps.want-lgtm.outputs.result ==  'true' }}
+        uses: 'actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410' # ratchet:actions/github-script@v6
+        with:
+          retries: 3
+          script: |-
+            // get all submitted reviews
+            const { data: submittedReviews } = await github.rest.pulls.listReviews({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+
+            // multiple users can submit multiple reviews with different statuses
+            // aggregate the status per login in chronological order to get latest status
+            const reviewStateByLogin = {};
+            submittedReviews
+              .sort((a, b) => new Date(a.submitted_at) - new Date(b.submitted_at))
+              .forEach((r) => {
+                reviewStateByLogin[r.user.login] = r.state;
+              });
+
+            // get all reviews without an approved status
+            const unapprovedReviews = Object.entries(reviewStateByLogin)
+              .filter(([key, value]) => value.toUpperCase() !== "APPROVED")
+              .map(([key, value]) => key);
+
+            core.info("Unapproved review(s): " + JSON.stringify(unapprovedReviews));
+
+            if (unapprovedReviews.length > 0) {
+              core.setFailed("Unapproved review(s): " + unapprovedReviews.join(", "));
+              return;
+            }
+
+            let { data: requestedReviewers } =
+              await github.rest.pulls.listRequestedReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+              });
+
+            const pendingUserApprovals = requestedReviewers.users.map((u) => u.login);
+            const pendingTeamApprovals = requestedReviewers.teams.map((t) => t.slug);
+
+            const pendingApprovals = [...pendingUserApprovals, ...pendingTeamApprovals];
+
+            core.info("Pending approval(s): " + JSON.stringify(pendingApprovals));
+
+            if (pendingApprovals.length > 0) {
+              core.setFailed("Pending approval(s): " + pendingApprovals.join(", "));
+              return;
+            }
+
+            // sanity check, require at least one reviewer
+            if (submittedReviews.length === 0 && pendingApprovals.length === 0) {
+              core.setFailed(
+                "At least one reviewer is required when specifying want_lgtm_all. Please add a reviewer or remove want_lgtm_all from the PR body."
+              );
+              return;
+            }
+
+      # when a pull_request_review is submitted and all required reviewers have approved
+      # we need to re-trigger any previously failed pull_request event for our workflow
+      # this is because pull_request and pull_request_review are seen as two different
+      # status checks by github
+      - id: 'rerun-status-checks'
+        name: 'Re-run Status Checks'
+        if: ${{ steps.want-lgtm.outputs.result ==  'true' && github.event_name == 'pull_request_review' }}
+        uses: 'actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410' # ratchet:actions/github-script@v6
+        with:
+          retries: 3
+          script: |-
+            // get the filename for this workflow
+            var workflowFilename = process.env.GITHUB_WORKFLOW_REF.split("@")[0]
+              .split("/")
+              .pop();
+
+            // get the latest failed workflow runs for our file and this branch
+            let workflows = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: workflowFilename,
+              branch: context.payload.pull_request.head.ref,
+              event: "pull_request",
+              status: "failure",
+              per_page: 100,
+            });
+
+            // filter workflow runs only for this pull request number
+            let unsuccessfulRuns = workflows.data.workflow_runs
+              .filter((w) =>
+                w.pull_requests.map((p) => p.number).includes(context.issue.number)
+              )
+              .sort((x) => x.id);
+
+            // retrigger the latest run for our unsuccessful workflow run
+            if (unsuccessfulRuns.length > 0) {
+              await github.rest.actions.reRunWorkflow({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                run_id: unsuccessfulRuns[0].id,
+              });
+            }

--- a/.github/workflows/want-lgtm-all.yml
+++ b/.github/workflows/want-lgtm-all.yml
@@ -3,20 +3,19 @@ name: 'want-lgtm-all'
 on:
   pull_request:
     types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
-      - ready_for_review
-      - review_requested
-      - review_request_removed
+      - 'opened'
+      - 'edited'
+      - 'reopened'
+      - 'synchronize'
+      - 'ready_for_review'
+      - 'review_requested'
+      - 'review_request_removed'
   pull_request_review:
     types:
-      - submitted
-      - dismissed
-      - edited
+      - 'submitted'
+      - 'dismissed'
+      - 'edited'
   workflow_call:
-  workflow_dispatch:
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
@@ -27,22 +26,10 @@ permissions:
   pull-requests: 'read'
 
 jobs:
-  validate:
+  want-lgtm-all:
+    if: ${{ contains(fromJSON('["pull_request", "pull_request_review"]'), github.event_name) }}
     runs-on: 'ubuntu-latest'
     steps:
-      - id: 'validate-event'
-        name: 'Validate GitHub Event'
-        uses: 'actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410' # ratchet:actions/github-script@v6
-        with:
-          script: |-
-            // validate required event names
-            if (!["pull_request", "pull_request_review"].includes(context.eventName)) {
-              core.setFailed(
-                "want-lgtm-all only supports the pull_request and pull_request_review event triggers. Please modify your workflow and try again."
-              );
-              return;
-            }
-
       - id: 'want-lgtm'
         name: 'Validate PR Body'
         uses: 'actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410' # ratchet:actions/github-script@v6
@@ -52,8 +39,8 @@ jobs:
             const body = context.payload.pull_request.body || "";
 
             // if PR body does not contain want_lgtm_all, exit gracefully
-            if (!body.match(/want_lgtm_all/gim)) {
-              core.info("PR body does not contain want_lgtm_all");
+            if (!body.toLowerCase().includes("want_lgtm=all")) {
+              core.info("PR body does not contain want_lgtm=all");
               return "false";
             }
 
@@ -77,9 +64,28 @@ jobs:
             // aggregate the status per login in chronological order to get latest status
             const reviewStateByLogin = {};
             submittedReviews
+              .filter((r) => r.user.login !== context.payload.pull_request.user.login)
               .sort((a, b) => new Date(a.submitted_at) - new Date(b.submitted_at))
               .forEach((r) => {
-                reviewStateByLogin[r.user.login] = r.state;
+                // add value if it doesnt not exist
+                if (!Object.hasOwn(reviewStateByLogin, r.user.login)) {
+                  reviewStateByLogin[r.user.login] = r.state;
+                  return;
+                }
+
+                // always update state if not approved
+                if (reviewStateByLogin[r.user.login] !== "APPROVED") {
+                  reviewStateByLogin[r.user.login] = r.state;
+                  return;
+                }
+
+                // do not update approved state for comment
+                if (
+                  reviewStateByLogin[r.user.login] === "APPROVED" &&
+                  r.state !== "COMMENTED"
+                ) {
+                  reviewStateByLogin[r.user.login] = r.state;
+                }
               });
 
             // get all reviews without an approved status
@@ -133,12 +139,12 @@ jobs:
           retries: 3
           script: |-
             // get the filename for this workflow
-            var workflowFilename = process.env.GITHUB_WORKFLOW_REF.split("@")[0]
+            const workflowFilename = process.env.GITHUB_WORKFLOW_REF.split("@")[0]
               .split("/")
               .pop();
 
             // get the latest failed workflow runs for our file and this branch
-            let workflows = await github.rest.actions.listWorkflowRuns({
+            let { data: workflows } = await github.rest.actions.listWorkflowRuns({
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: workflowFilename,
@@ -149,7 +155,7 @@ jobs:
             });
 
             // filter workflow runs only for this pull request number
-            let unsuccessfulRuns = workflows.data.workflow_runs
+            let unsuccessfulRuns = workflows.workflow_runs
               .filter((w) =>
                 w.pull_requests.map((p) => p.number).includes(context.issue.number)
               )

--- a/.github/workflows/want-lgtm-all.yml
+++ b/.github/workflows/want-lgtm-all.yml
@@ -54,7 +54,7 @@ jobs:
           retries: 3
           script: |-
             // get all submitted reviews
-            const { data: submittedReviews } = await github.rest.pulls.listReviews({
+            const submittedReviews = await github.paginate(github.rest.pulls.listReviews, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               pull_number: context.issue.number,
@@ -100,7 +100,7 @@ jobs:
               return;
             }
 
-            let { data: requestedReviewers } =
+            const { data: requestedReviewers } =
               await github.rest.pulls.listRequestedReviewers({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -144,7 +144,7 @@ jobs:
               .pop();
 
             // get the latest failed workflow runs for our file and this branch
-            let { data: workflows } = await github.rest.actions.listWorkflowRuns({
+            const workflows = await github.paginate(github.rest.actions.listWorkflowRuns, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               workflow_id: workflowFilename,
@@ -155,7 +155,7 @@ jobs:
             });
 
             // filter workflow runs only for this pull request number
-            let unsuccessfulRuns = workflows.workflow_runs
+            const unsuccessfulRuns = workflows
               .filter((w) =>
                 w.pull_requests.map((p) => p.number).includes(context.issue.number)
               )

--- a/README.md
+++ b/README.md
@@ -7,14 +7,12 @@
 abcxyz `pkg` provides a place for sharing common abcxyz packages across the
 abcxyz repos.
 
-
 ## GitHub Actions
 
 There are reusable workflows inside [./.github/workflows](.github/workflows),
 which encapsulate common CI/CD logic to reduce repetition. For security, the
 reusable workflows are pinned to specific references using
 [ratchet](https://github.com/sethvargo/ratchet).
-
 
 #### go-lint.yml
 
@@ -24,27 +22,26 @@ Use this workflow to perform basic Go linting checks:
 on:
   push:
     branches:
-      - 'main'
+      - "main"
     paths:
-      - '**.go'
+      - "**.go"
   pull_request:
     branches:
-      - 'main'
+      - "main"
     paths:
-      - '**.go'
+      - "**.go"
   workflow_dispatch:
 
 jobs:
   lint:
-    uses: 'abcxyz/pkg/.github/workflows/go-lint.yml@main'
+    uses: "abcxyz/pkg/.github/workflows/go-lint.yml@main"
     with:
-      go_version: '1.20'
+      go_version: "1.20"
 ```
 
 Linting is done via [golangci-lint](https://golangci-lint.run/). If a
 `.golangci.yml` file exists at the root of the repository, it uses those linter
 settings. Otherwise, it uses a set of sane defaults.
-
 
 #### go-test.yml
 
@@ -54,30 +51,29 @@ Use this workflow to perform basic Go tests:
 on:
   push:
     branches:
-      - 'main'
+      - "main"
     paths:
-      - '**.go'
+      - "**.go"
   pull_request:
     branches:
-      - 'main'
+      - "main"
     paths:
-      - '**.go'
+      - "**.go"
   workflow_dispatch:
 
 jobs:
   lint:
-    uses: 'abcxyz/pkg/.github/workflows/go-test.yml@main'
+    uses: "abcxyz/pkg/.github/workflows/go-test.yml@main"
     with:
-      go_version: '1.20'
+      go_version: "1.20"
 ```
 
 Testing is done via the `go test` command with:
 
--   Test caching disabled
--   Test shuffling enabled
--   Race detector enabled
--   A 10 minute timeout
-
+- Test caching disabled
+- Test shuffling enabled
+- Race detector enabled
+- A 10 minute timeout
 
 #### terraform-lint.yml
 
@@ -87,22 +83,22 @@ Use this workflow to perform basic Terraform linting checks:
 on:
   push:
     branches:
-      - 'main'
+      - "main"
     paths:
-      - '**.tf'
+      - "**.tf"
   pull_request:
     branches:
-      - 'main'
+      - "main"
     paths:
-      - '**.tf'
+      - "**.tf"
   workflow_dispatch:
 
 jobs:
   lint:
-    uses: 'abcxyz/pkg/.github/workflows/terraform-lint.yml@main'
+    uses: "abcxyz/pkg/.github/workflows/terraform-lint.yml@main"
     with:
-      terraform_version: '1.2'
-      directory: './terraform'
+      terraform_version: "1.2"
+      directory: "./terraform"
 ```
 
 If you have multiple Terraform configurations, repeat the stanza for each
@@ -112,3 +108,37 @@ directory. Linting is done in two steps:
 
 1.  Run `terraform fmt` and check the git diff. This will will if the Terraform
     file is not formatted. On failure, the output will include the diff.
+
+#### want-lgtm-all.yml
+
+Use this workflow to require an approval from all requested reviewers:
+
+```yaml
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - ready_for_review
+      - review_requested
+      - review_request_removed
+  pull_request_review:
+    types:
+      - submitted
+      - dismissed
+      - edited
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}"
+  cancel-in-progress: true
+
+permissions:
+  actions: "write"
+  pull-requests: "read"
+
+jobs:
+  want-lgtm-all:
+    uses: "abcxyz/pkg/.github/workflows/want-lgtm-all.yml@main"
+```

--- a/README.md
+++ b/README.md
@@ -7,12 +7,14 @@
 abcxyz `pkg` provides a place for sharing common abcxyz packages across the
 abcxyz repos.
 
+
 ## GitHub Actions
 
 There are reusable workflows inside [./.github/workflows](.github/workflows),
 which encapsulate common CI/CD logic to reduce repetition. For security, the
 reusable workflows are pinned to specific references using
 [ratchet](https://github.com/sethvargo/ratchet).
+
 
 #### go-lint.yml
 
@@ -22,26 +24,27 @@ Use this workflow to perform basic Go linting checks:
 on:
   push:
     branches:
-      - "main"
+      - 'main'
     paths:
-      - "**.go"
+      - '**.go'
   pull_request:
     branches:
-      - "main"
+      - 'main'
     paths:
-      - "**.go"
+      - '**.go'
   workflow_dispatch:
 
 jobs:
   lint:
-    uses: "abcxyz/pkg/.github/workflows/go-lint.yml@main"
+    uses: 'abcxyz/pkg/.github/workflows/go-lint.yml@main'
     with:
-      go_version: "1.20"
+      go_version: '1.20'
 ```
 
 Linting is done via [golangci-lint](https://golangci-lint.run/). If a
 `.golangci.yml` file exists at the root of the repository, it uses those linter
 settings. Otherwise, it uses a set of sane defaults.
+
 
 #### go-test.yml
 
@@ -51,29 +54,30 @@ Use this workflow to perform basic Go tests:
 on:
   push:
     branches:
-      - "main"
+      - 'main'
     paths:
-      - "**.go"
+      - '**.go'
   pull_request:
     branches:
-      - "main"
+      - 'main'
     paths:
-      - "**.go"
+      - '**.go'
   workflow_dispatch:
 
 jobs:
   lint:
-    uses: "abcxyz/pkg/.github/workflows/go-test.yml@main"
+    uses: 'abcxyz/pkg/.github/workflows/go-test.yml@main'
     with:
-      go_version: "1.20"
+      go_version: '1.20'
 ```
 
 Testing is done via the `go test` command with:
 
-- Test caching disabled
-- Test shuffling enabled
-- Race detector enabled
-- A 10 minute timeout
+-   Test caching disabled
+-   Test shuffling enabled
+-   Race detector enabled
+-   A 10 minute timeout
+
 
 #### terraform-lint.yml
 
@@ -83,22 +87,22 @@ Use this workflow to perform basic Terraform linting checks:
 on:
   push:
     branches:
-      - "main"
+      - 'main'
     paths:
-      - "**.tf"
+      - '**.tf'
   pull_request:
     branches:
-      - "main"
+      - 'main'
     paths:
-      - "**.tf"
+      - '**.tf'
   workflow_dispatch:
 
 jobs:
   lint:
-    uses: "abcxyz/pkg/.github/workflows/terraform-lint.yml@main"
+    uses: 'abcxyz/pkg/.github/workflows/terraform-lint.yml@main'
     with:
-      terraform_version: "1.2"
-      directory: "./terraform"
+      terraform_version: '1.2'
+      directory: './terraform'
 ```
 
 If you have multiple Terraform configurations, repeat the stanza for each
@@ -117,28 +121,30 @@ Use this workflow to require an approval from all requested reviewers:
 on:
   pull_request:
     types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
-      - ready_for_review
-      - review_requested
-      - review_request_removed
+      - 'opened'
+      - 'edited'
+      - 'reopened'
+      - 'synchronize'
+      - 'ready_for_review'
+      - 'review_requested'
+      - 'review_request_removed'
   pull_request_review:
     types:
-      - submitted
-      - dismissed
-      - edited
+      - 'submitted'
+      - 'dismissed'
+      - 'edited'
 
 concurrency:
-  group: "${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}"
+  group: '${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true
 
 permissions:
-  actions: "write"
-  pull-requests: "read"
+  actions: 'write'
+  pull-requests: 'read'
 
 jobs:
   want-lgtm-all:
-    uses: "abcxyz/pkg/.github/workflows/want-lgtm-all.yml@main"
+    uses: 'abcxyz/pkg/.github/workflows/want-lgtm-all.yml@main'
 ```
+
+When creating a pull request, include the text `want_lgtm=all` in the body to require an approval from all requested reviewers.


### PR DESCRIPTION
Porting the `want-lgtm-all` workflow from the hackathon. This changes from using labels to using a regex to find the `want_lgtm=all` string in the pull request body.

This also fixes a bug where submitted reviews could be request changes and not approved.