### PR TITLE
Fetch pr body from api instead of context

### DIFF
--- a/.github/workflows/want-lgtm-all.yml
+++ b/.github/workflows/want-lgtm-all.yml
@@ -36,7 +36,12 @@ jobs:
         with:
           result-encoding: 'string'
           script: |-
-            const body = context.payload.pull_request.body || "";
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+            const body = pullRequest.body || "";
 
             // if PR body does not contain want_lgtm_all, exit gracefully
             if (!body.toLowerCase().includes("want_lgtm=all")) {


### PR DESCRIPTION
The lgtm workflow fetches the PR body from the context of the Github Action workflow. This means the body is versioned to the snapshot of whatever the body was at the time the workflow was kicked off. In practice, this can cause an unmergable PR if the tag is removed from the PR. Ex.

1. Create PR with lgtm tag
2. Add reviewers to PR
3. Single reviewer approves -> want_lgtm fails because not all have approved
4. Remove the tag
5. The "pull_request_review" trigger will still fail even if the workflow is re-ran. The workflow still uses the context from when want_lgtm tag was present. Only way to pass the workflow is to add another review, or change the existing review.

Instead, we should fetch the latest version of the Pull Request body when the workflow runs.