### PR TITLE
POC logger factory

### DIFF
--- a/logging/logger.go
+++ b/logging/logger.go
@@ -42,15 +42,40 @@ var (
 	defaultLoggerOnce sync.Once
 )
 
+// type MyCommand struct {
+// 	lf *logging.Factory
+// }
+
+// // Run
+//
+//	func (c *MyCommand) Run() error {
+//		logger := c.lf.NewLogger()
+//	}
+type Factory struct {
+	Level string
+	Mode  string
+}
+
+func (f *Factory) NewLogger() *zap.SugaredLogger {
+	return newLogger(f.Level, f.Mode)
+}
+
 // NewFromEnv creates a new logger from env vars.
 // Set envPrefix+"LOG_LEVEL" to overwrite log level. Default log level is warning.
 // Set envPrefix+"LOG_MODE" to overwrite log mode. Default log mode is production.
 func NewFromEnv(envPrefix string) *zap.SugaredLogger {
 	level := os.Getenv(envPrefix + "LOG_LEVEL")
-	logMode := strings.ToLower(strings.TrimSpace(os.Getenv(envPrefix + "LOG_MODE")))
-	devMode := strings.HasPrefix(logMode, "dev")
+	mode := strings.ToLower(strings.TrimSpace(os.Getenv(envPrefix + "LOG_MODE")))
+	return newLogger(level, mode)
+}
+
+func newLogger(level, mode string) *zap.SugaredLogger {
+	if level == "" {
+		level = "warn"
+	}
+	isDevMode := strings.HasPrefix(mode, "dev")
 	var cfg zap.Config
-	if devMode {
+	if isDevMode {
 		cfg = zap.NewDevelopmentConfig()
 		cfg.EncoderConfig = developmentEncoderConfig
 	} else {

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -42,21 +42,23 @@ var (
 	defaultLoggerOnce sync.Once
 )
 
-// type MyCommand struct {
-// 	lf *logging.Factory
-// }
-
-// // Run
-//
-//	func (c *MyCommand) Run() error {
-//		logger := c.lf.NewLogger()
-//	}
+// Factory is a factory to create loggers.
 type Factory struct {
-	Level string
-	Mode  string
+	Level, Mode string
 }
 
-func (f *Factory) NewLogger() *zap.SugaredLogger {
+// SetLevel sets the level for the logger factory.
+func (f *Factory) SetLevel(level string) {
+	f.Level = level
+}
+
+// SetMode sets the mode for the logger factory.
+func (f *Factory) SetMode(mode string) {
+	f.Mode = mode
+}
+
+// New creates a new logger.
+func (f *Factory) New() *zap.SugaredLogger {
 	return newLogger(f.Level, f.Mode)
 }
 
@@ -74,6 +76,7 @@ func newLogger(level, mode string) *zap.SugaredLogger {
 		level = "warn"
 	}
 	isDevMode := strings.HasPrefix(mode, "dev")
+
 	var cfg zap.Config
 	if isDevMode {
 		cfg = zap.NewDevelopmentConfig()


### PR DESCRIPTION
Challenges

To have something like described in https://github.com/abcxyz/pkg/pull/124#discussion_r1201122470, we need setters on the **logger** to update level or encoding. However, `zap` doesn't provide any setters to change log level or encoding on an existing logger (same as `slog`). To have a logger with desired level or encoding, we have create a new logger.

First I tried to create a wrapper around the native logger, like

```go
type Logger struct {
  *zap.SugaredLogger
  Options *Options
}

type Options struct {
  Level, Mode string
}
```

This worked poorly because we need to change logger type _everywhere_ it's used. Considering we will try to move to `slog` once it's out of `exp`, I don't think it worths the effort to do so.

So instead, I tried the way in this PR. Instead of initializing a logger directly from flags, we initialize a logger factory and use the factory to create loggers. I think this would work for `slog` as well.