### PR TITLE
Fix CLI flag bug in handling default value with setter

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -301,7 +301,7 @@ func Flag[T any](f *FlagSection, i *Var[T]) {
 	}
 
 	// Set a default value.
-	*i.Target = initial
+	setter(i.Target, initial)
 
 	// Compute a sane default if one was not given.
 	example := i.Example


### PR DESCRIPTION
Without this fix, the default value will be ignored in a custom `setter` function.

want_lgtm=@sethvargo 