### PR TITLE
Tweak the grammar of DiffErrStrings outputs

### DIFF
--- a/testutil/error.go
+++ b/testutil/error.go
@@ -27,13 +27,13 @@ func DiffErrString(got error, want string) string {
 		if got == nil {
 			return ""
 		}
-		return fmt.Sprintf("expected error %q to be <nil>", got.Error())
+		return fmt.Sprintf("got error %q but want <nil>", got.Error())
 	}
 	if got == nil {
-		return fmt.Sprintf("expected error <nil> to contain %q", want)
+		return fmt.Sprintf("got error <nil> but want an error containing %q", want)
 	}
 	if msg := got.Error(); !strings.Contains(msg, want) {
-		return fmt.Sprintf("expected error %q to contain %q", msg, want)
+		return fmt.Sprintf("got error %q but want an error containing %q", msg, want)
 	}
 	return ""
 }

--- a/testutil/error_test.go
+++ b/testutil/error_test.go
@@ -34,18 +34,18 @@ func TestDiffErrString(t *testing.T) {
 		{
 			name:     "empty_string_err",
 			err:      fmt.Errorf("some err"),
-			wantDiff: `expected error "some err" to be <nil>`,
+			wantDiff: `got error "some err" but want <nil>`,
 		},
 		{
 			name:     "non_empty_string_nil_err",
 			msg:      "some err",
-			wantDiff: `expected error <nil> to contain "some err"`,
+			wantDiff: `got error <nil> but want an error containing "some err"`,
 		},
 		{
 			name:     "err_mismatch",
 			msg:      "some err",
 			err:      fmt.Errorf("other err"),
-			wantDiff: `expected error "other err" to contain "some err"`,
+			wantDiff: `got error "other err" but want an error containing "some err"`,
 		},
 		{
 			name: "err_match",


### PR DESCRIPTION
The previous output is slightly problematic because it contains grammatical ambigity that is only resolved after the first error message is printed. It's a [Garden-path sentence](https://en.wikipedia.org/wiki/Garden-path_sentence).

When an error message is large, the user sees `expected error <wall of text>.....`. The obvious mental parsing of this is incorrect: "[we] expected [the] error [to be] <wall of text>". Once the user finds the remainder of the message after the wall of text, they find out that their mental parse tree should actually be "[we] expected [that the actual] error [we got which was] <wall of text>...". The problem is exacerbated for large error messages where the sentence structure is not visible at a glance.