### PR TITLE
Add override-workflow-variables action

### DIFF
--- a/.github/actions/override-variables/action.yml
+++ b/.github/actions/override-variables/action.yml
@@ -45,16 +45,15 @@ runs:
         REQUIRE_ENV: '${{ inputs.require_env }}'
         ENFORCED_DIRECTORIES: '${{ inputs.enforced_directories }}'
       run: |-
-        echo $GITHUB_WORKSPACE
-        echo $PWD
         if [ -f "$ENV_FILE" ]; then
           # Filter out comment lines, empty lines, and lines with only whitespace.
           grep -v '^[[:space:]]*#\|^$\|^\s*$' $ENV_FILE >> ${GITHUB_ENV}
         elif [ "$REQUIRE_ENV" == true ]; then
           # Replace , with space to make values iterable.
           for REQUIRED_DIR in ${ENFORCED_DIRECTORIES//,/ }; do
-            echo $REQUIRED_DIR
-            if [[ "$REQUIRED_DIR"* == $PWD ]]; then
+
+            ENFORCED_PATH="${GITHUB_WORKSPACE}/${REQUIRED_DIR}"
+            if [[ "$ENFORCED_PATH" == $PWD ]]; then
               echo "::error::env file is missing in $PWD"
               exit 1
             fi

--- a/.github/actions/override-variables/action.yml
+++ b/.github/actions/override-variables/action.yml
@@ -45,15 +45,15 @@ runs:
         REQUIRE_ENV: '${{ inputs.require_env }}'
         ENFORCED_DIRECTORIES: '${{ inputs.enforced_directories }}'
       run: |-
-        $GITHUB_WORKSPACE
-        $PWD
+        echo $GITHUB_WORKSPACE
+        echo $PWD
         if [ -f "$ENV_FILE" ]; then
           # Filter out comment lines, empty lines, and lines with only whitespace.
           grep -v '^[[:space:]]*#\|^$\|^\s*$' $ENV_FILE >> ${GITHUB_ENV}
         elif [ "$REQUIRE_ENV" == true ]
           # Replace , with space to make values iterable.
           for REQUIRED_DIR in ${ENFORCED_DIRECTORIES//,/ }; do
-            $REQUIRED_DIR
+            echo $REQUIRED_DIR
             if [[ "$REQUIRED_DIR"* == $PWD ]]; then
               echo "::error::env file is missing in $PWD"
               exit 1

--- a/.github/actions/override-variables/action.yml
+++ b/.github/actions/override-variables/action.yml
@@ -50,9 +50,14 @@ runs:
           grep -v '^[[:space:]]*#\|^$\|^\s*$' $ENV_FILE >> ${GITHUB_ENV}
         elif [ "$REQUIRE_ENV" == true ]; then
           # Replace , with space to make values iterable.
+
+          echo $ENFORCED_DIRECTORIES
+          echo ${ENFORCED_DIRECTORIES//,/ }
           for REQUIRED_DIR in ${ENFORCED_DIRECTORIES//,/ }; do
 
             ENFORCED_PATH="${GITHUB_WORKSPACE}/${REQUIRED_DIR}"
+            echo $ENFORCED_PATH
+            echo $PWD
             if [[ "$ENFORCED_PATH" == $PWD ]]; then
               echo "::error::env file is missing in $PWD"
               exit 1

--- a/.github/actions/override-variables/action.yml
+++ b/.github/actions/override-variables/action.yml
@@ -1,0 +1,61 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Override Variables'
+description: |-
+  Use this action to load/override variables into GITHUB_ENV.
+
+inputs:
+  working_directory:
+    description: 'The working directory to look for the env file.'
+    required: false
+    default: '.'
+  env_file:
+    description: 'The env file containing variables to override with.'
+    required: false
+    default: '.env'
+  require_env:
+    description: 'Require the use of an env file for overriding variables.'
+    required: false
+    default: 'false'
+  enforced_directories:
+    description: 'The directory to require the use of an env file for overriding variables.'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Load Guardian Env File'
+      shell: 'bash'
+      working-directory: '${{ inputs.working_directory }}'
+      env:
+        ENV_FILE: '${{ inputs.env_file }}'
+        REQUIRE_ENV: '${{ inputs.require_env }}'
+        ENFORCED_DIRECTORIES: '${{ inputs.enforced_directories }}'
+      run: |-
+        $GITHUB_WORKSPACE
+        if [ -f "$ENV_FILE" ]; then
+          # Filter out comment lines, empty lines, and lines with only whitespace.
+          grep -v '^[[:space:]]*#\|^$\|^\s*$' $ENV_FILE >> ${GITHUB_ENV}
+        elif [ "$REQUIRE_ENV" == true ]
+          # Replace , with space to make values iterable.
+          for REQUIRED_DIR in ${ENFORCED_DIRECTORIES//,/ }; do
+
+            if [[ "$REQUIRED_DIR"* == $PWD ]]; then
+              echo "::error::env file is missing in $PWD"
+              exit 1
+            if
+          done
+        fi

--- a/.github/actions/override-variables/action.yml
+++ b/.github/actions/override-variables/action.yml
@@ -53,6 +53,7 @@ runs:
           for REQUIRED_DIR in ${ENFORCED_DIRECTORIES//,/ }; do
 
             ENFORCED_PATH="${GITHUB_WORKSPACE}/${REQUIRED_DIR}"
+            # Fail if the current directory is subdirectory of an enforced directory.
             if [[ "$PWD" = "$ENFORCED_PATH"* ]]; then
               echo "::error::env file is missing in $PWD"
               exit 1

--- a/.github/actions/override-variables/action.yml
+++ b/.github/actions/override-variables/action.yml
@@ -50,7 +50,7 @@ runs:
         if [ -f "$ENV_FILE" ]; then
           # Filter out comment lines, empty lines, and lines with only whitespace.
           grep -v '^[[:space:]]*#\|^$\|^\s*$' $ENV_FILE >> ${GITHUB_ENV}
-        elif [ "$REQUIRE_ENV" == true ]
+        elif [ "$REQUIRE_ENV" == true ]; then
           # Replace , with space to make values iterable.
           for REQUIRED_DIR in ${ENFORCED_DIRECTORIES//,/ }; do
             echo $REQUIRED_DIR

--- a/.github/actions/override-variables/action.yml
+++ b/.github/actions/override-variables/action.yml
@@ -50,15 +50,10 @@ runs:
           grep -v '^[[:space:]]*#\|^$\|^\s*$' $ENV_FILE >> ${GITHUB_ENV}
         elif [ "$REQUIRE_ENV" == true ]; then
           # Replace , with space to make values iterable.
-
-          echo $ENFORCED_DIRECTORIES
-          echo ${ENFORCED_DIRECTORIES//,/ }
           for REQUIRED_DIR in ${ENFORCED_DIRECTORIES//,/ }; do
 
             ENFORCED_PATH="${GITHUB_WORKSPACE}/${REQUIRED_DIR}"
-            echo $ENFORCED_PATH
-            echo $PWD
-            if [[ "$ENFORCED_PATH" == $PWD ]]; then
+            if [[ "$PWD" = "$ENFORCED_PATH"* ]]; then
               echo "::error::env file is missing in $PWD"
               exit 1
             fi

--- a/.github/actions/override-variables/action.yml
+++ b/.github/actions/override-variables/action.yml
@@ -46,13 +46,14 @@ runs:
         ENFORCED_DIRECTORIES: '${{ inputs.enforced_directories }}'
       run: |-
         $GITHUB_WORKSPACE
+        $PWD
         if [ -f "$ENV_FILE" ]; then
           # Filter out comment lines, empty lines, and lines with only whitespace.
           grep -v '^[[:space:]]*#\|^$\|^\s*$' $ENV_FILE >> ${GITHUB_ENV}
         elif [ "$REQUIRE_ENV" == true ]
           # Replace , with space to make values iterable.
           for REQUIRED_DIR in ${ENFORCED_DIRECTORIES//,/ }; do
-
+            $REQUIRED_DIR
             if [[ "$REQUIRED_DIR"* == $PWD ]]; then
               echo "::error::env file is missing in $PWD"
               exit 1

--- a/.github/actions/override-variables/action.yml
+++ b/.github/actions/override-variables/action.yml
@@ -57,6 +57,6 @@ runs:
             if [[ "$REQUIRED_DIR"* == $PWD ]]; then
               echo "::error::env file is missing in $PWD"
               exit 1
-            if
+            fi
           done
         fi

--- a/.github/actions/override-workflow-variables/action.yml
+++ b/.github/actions/override-workflow-variables/action.yml
@@ -26,7 +26,7 @@ inputs:
     required: false
     default: '.env'
   require_env:
-    description: 'fail if the env file isn't found; unless enforced_directories is set, every working_directory must have an .env file'
+    description: 'fail if the env file isn't found; unless enforced_directories is set, every working_directory must have an .env file.'
     required: false
     default: 'false'
   enforced_directories:

--- a/.github/actions/override-workflow-variables/action.yml
+++ b/.github/actions/override-workflow-variables/action.yml
@@ -26,7 +26,7 @@ inputs:
     required: false
     default: '.env'
   require_env:
-    description: 'fail if the env file isn't found; unless enforced_directories is set, every working_directory must have an .env file.'
+    description: 'fail if the env file is not found; unless enforced_directories is set, every working_directory must have an .env file.'
     required: false
     default: 'false'
   enforced_directories:

--- a/.github/actions/override-workflow-variables/action.yml
+++ b/.github/actions/override-workflow-variables/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: false
     default: 'false'
   enforced_directories:
-    description: 'only used when require_env=true; rather than looking for an env file in every immediate subdirectory, just require it in this set of directories.'
+    description: 'only used when require_env=true; rather than looking for an env file in all working-directories, just require it in working-directories belonging to this set of parent directories.'
     required: false
     default: ''
 

--- a/.github/actions/override-workflow-variables/action.yml
+++ b/.github/actions/override-workflow-variables/action.yml
@@ -49,6 +49,12 @@ runs:
           # Filter out comment lines, empty lines, and lines with only whitespace.
           grep -v '^[[:space:]]*#\|^$\|^\s*$' $ENV_FILE >> ${GITHUB_ENV}
         elif [ "$REQUIRE_ENV" == true ]; then
+
+          if [ "$ENFORCED_DIRECTORIES" == "" ]; then
+            # Set to top-level dir of respository to enforce on all subdirectories.
+            ENFORCED_DIRECTORIES="$GITHUB_WORKSPACE"
+          fi
+
           # Replace , with space to make values iterable.
           for REQUIRED_DIR in ${ENFORCED_DIRECTORIES//,/ }; do
 

--- a/.github/actions/override-workflow-variables/action.yml
+++ b/.github/actions/override-workflow-variables/action.yml
@@ -30,7 +30,7 @@ inputs:
     required: false
     default: 'false'
   enforced_directories:
-    description: 'The directory to require the use of an env file for overriding variables.'
+    description: 'A CSV string of directories to require the use of an env file for overriding variables.'
     required: false
     default: ''
 

--- a/.github/actions/override-workflow-variables/action.yml
+++ b/.github/actions/override-workflow-variables/action.yml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: 'Override Variables'
+name: 'Override Workflow Variables'
 description: |-
   Use this action to load/override variables into GITHUB_ENV.
 
@@ -37,7 +37,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: 'Load Guardian Env File'
+    - name: 'Load Env File'
       shell: 'bash'
       working-directory: '${{ inputs.working_directory }}'
       env:

--- a/.github/actions/override-workflow-variables/action.yml
+++ b/.github/actions/override-workflow-variables/action.yml
@@ -26,11 +26,11 @@ inputs:
     required: false
     default: '.env'
   require_env:
-    description: 'Require the use of an env file for overriding variables.'
+    description: 'fail if the env file isn't found; unless enforced_directories is set, every working_directory must have an .env file'
     required: false
     default: 'false'
   enforced_directories:
-    description: 'A CSV string of directories to require the use of an env file for overriding variables.'
+    description: 'only used when require_env=true; rather than looking for an env file in every immediate subdirectory, just require it in this set of directories.'
     required: false
     default: ''
 
@@ -51,7 +51,7 @@ runs:
         elif [ "$REQUIRE_ENV" == true ]; then
 
           if [ "$ENFORCED_DIRECTORIES" == "" ]; then
-            # Set to top-level dir of respository to enforce on all subdirectories.
+            # Set to top-level dir of respository to enforce on all working-directories.
             ENFORCED_DIRECTORIES="$GITHUB_WORKSPACE"
           fi
 


### PR DESCRIPTION
This is a reusable GitHub action for loading env variables from an env file of the working-directory, if it exists, into the `GITHUB_ENV` environment file. 

To require the use of an env file, set `require_env = 'true'`  and optionally specify `enforced_directories` (in CSV string) to enforce upon specific directories and their subdirectories. This is useful when you need separated env variables between directories.
