### PR TITLE
feat: programmatic fallback log level and mode

### DIFF
--- a/logging/logger.go
+++ b/logging/logger.go
@@ -46,12 +46,12 @@ var (
 // variables aren't set.
 type FallbackConfig struct {
 	// The log mode to use if the environment variable isn't set. Valid values
-	// are "dev" and "production".
+	// are "dev" and "production". May be empty to use the hardoded default.
 	ModeIfNoEnv string
 
 	// The log level to use if the environment variable isn't set. Valid values
 	// are anything accepted by zap (debug, info, warn, error, dpanic, panic,
-	// fatal).
+	// fatal). May be empty to use the hardoded default.
 	LevelIfNoEnv string
 }
 


### PR DESCRIPTION
This adds the function `logging.NewFromEnvWithDefaults()`. This allows the program to provide a log level and a mode (dev/prod) that will be used in the case that the _LOG_LEVEL and/or _LOG_MODE env vars aren't set.

The initial use case is for the abc CLI, where we want to use the "dev" log mode unless the user specifically requested otherwise by setting an env var.