### PR TITLE
Rename worker to workerpool

### DIFF
--- a/workerpool/workerpool.go
+++ b/workerpool/workerpool.go
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package worker defines abstractions for parallelizing tasks.
-package worker
+// Package workerpool defines abstractions for parallelizing tasks.
+package workerpool
 
 import (
 	"context"
@@ -34,9 +34,9 @@ type Void struct{}
 // WorkFunc is a function for executing work.
 type WorkFunc[T any] func() (T, error)
 
-// Worker represents an instance of a worker. It is same for concurrent use, but
-// see function documentation for more specific semantics.
-type Worker[T any] struct {
+// Pool represents an instance of a worker pool. It is same for concurrent use,
+// but see function documentation for more specific semantics.
+type Pool[T any] struct {
 	size int64
 	sem  *semaphore.Weighted
 
@@ -60,14 +60,14 @@ type Result[T any] struct {
 	Error error
 }
 
-// New creates a new worker that executes work in parallel, up to the maximum
-// provided concurrency. Work is guaranteed to be executed in the order in which
-// it was enqueued, but is not guaranteed to complete in the order in which it
-// was enqueued (i.e. this is not a pipeline).
+// New creates a new worker pool that executes work in parallel, up to the
+// maximum provided concurrency. Work is guaranteed to be executed in the order
+// in which it was enqueued, but is not guaranteed to complete in the order in
+// which it was enqueued (i.e. this is not a pipeline).
 //
 // If the provided concurrency is less than 1, it defaults to the number of CPU
 // cores.
-func New[T any](concurrency int64) *Worker[T] {
+func New[T any](concurrency int64) *Pool[T] {
 	if concurrency < 1 {
 		concurrency = int64(runtime.NumCPU())
 	}
@@ -75,7 +75,7 @@ func New[T any](concurrency int64) *Worker[T] {
 		concurrency = 1
 	}
 
-	return &Worker[T]{
+	return &Pool[T]{
 		size:    concurrency,
 		i:       -1,
 		sem:     semaphore.NewWeighted(concurrency),
@@ -83,46 +83,47 @@ func New[T any](concurrency int64) *Worker[T] {
 	}
 }
 
-// Do adds new work into the queue. If there are no available workers, it blocks
-// until a worker becomes available or until the provided context is cancelled.
-// The function returns when the work has been successfully scheduled.
+// Do adds new work into the queue. If there are no available workers in the
+// pool, it blocks until a worker becomes available or until the provided
+// context is cancelled. The function returns when the work has been
+// successfully scheduled.
 //
-// To wait for all work to be completed and read the results, call
-// [worker.Done]. This function only returns an error on two conditions:
+// To wait for all work to be completed and read the results, call [Pool.Done].
+// This function only returns an error on two conditions:
 //
-//   - The worker was stopped via a call to [worker.Done]. You should not
+//   - The worker pool was stopped via a call to [Pool.Done]. You should not
 //     enqueue more work. The error will be [ErrStopped].
 //   - The incoming context was cancelled. You should probably not enqueue more
 //     work, but this is an application-specific decision. The error will be
 //     [context.DeadlineExceeded] or [context.Canceled].
 //
 // Never call Do from within a Do function because it will deadlock.
-func (w *Worker[T]) Do(ctx context.Context, fn WorkFunc[T]) error {
-	// Do not enqueue new work if the worker is stopped.
-	if w.isStopped() {
+func (p *Pool[T]) Do(ctx context.Context, fn WorkFunc[T]) error {
+	// Do not enqueue new work if the worker pool is stopped.
+	if p.isStopped() {
 		return ErrStopped
 	}
 
-	if err := w.sem.Acquire(ctx, 1); err != nil {
+	if err := p.sem.Acquire(ctx, 1); err != nil {
 		return fmt.Errorf("failed to acquire semaphore: %w", err)
 	}
 
-	// It's possible the worker was stopped while we were waiting for the
-	// semaphore to acquire, but the worker is actually stopped.
-	if w.isStopped() {
-		w.sem.Release(1)
+	// It's possible the worker pool was stopped while we were waiting for the
+	// semaphore to acquire, but the worker pool is actually stopped.
+	if p.isStopped() {
+		p.sem.Release(1)
 		return ErrStopped
 	}
 
-	i := atomic.AddInt64(&w.i, 1)
+	i := atomic.AddInt64(&p.i, 1)
 
 	go func() {
-		defer w.sem.Release(1)
+		defer p.sem.Release(1)
 		t, err := fn()
 
-		w.resultsLock.Lock()
-		defer w.resultsLock.Unlock()
-		w.results = append(w.results, &result[T]{
+		p.resultsLock.Lock()
+		defer p.resultsLock.Unlock()
+		p.results = append(p.results, &result[T]{
 			idx: i,
 			result: &Result[T]{
 				Value: t,
@@ -134,37 +135,38 @@ func (w *Worker[T]) Do(ctx context.Context, fn WorkFunc[T]) error {
 	return nil
 }
 
-// Done immediately stops the worker and prevents new work from being enqueued.
-// Then it waits for all existing work to finish and results the results.
+// Done immediately stops the worker pool and prevents new work from being
+// enqueued. Then it waits for all existing work to finish and results the
+// results.
 //
 // The results are returned in the order in which jobs were enqueued into the
-// worker. Each result will include a result value or corresponding error type.
-// The function itself returns an error only if the context is cancelled.
+// worker pool. Each result will include a result value or corresponding error
+// type. The function itself returns an error only if the context is cancelled.
 //
-// If the worker is already done, it returns [ErrStopped].
-func (w *Worker[T]) Done(ctx context.Context) ([]*Result[T], error) {
-	if !atomic.CompareAndSwapUint32(&w.stopped, 0, 1) {
+// If the worker pool is already done, it returns [ErrStopped].
+func (p *Pool[T]) Done(ctx context.Context) ([]*Result[T], error) {
+	if !atomic.CompareAndSwapUint32(&p.stopped, 0, 1) {
 		return nil, ErrStopped
 	}
 
-	if err := w.sem.Acquire(ctx, w.size); err != nil {
+	if err := p.sem.Acquire(ctx, p.size); err != nil {
 		return nil, fmt.Errorf("failed to acquire semaphore: %w", err)
 	}
-	defer w.sem.Release(w.size)
+	defer p.sem.Release(p.size)
 
-	w.resultsLock.Lock()
-	defer w.resultsLock.Unlock()
+	p.resultsLock.Lock()
+	defer p.resultsLock.Unlock()
 
 	// Fix insertion order.
-	final := make([]*Result[T], len(w.results))
-	for _, v := range w.results {
+	final := make([]*Result[T], len(p.results))
+	for _, v := range p.results {
 		final[v.idx] = v.result
 	}
 	return final, nil
 }
 
-// isStopped returns true if the worker is stopped, false otherwise. It is safe
-// for concurrent use.
-func (w *Worker[T]) isStopped() bool {
-	return atomic.LoadUint32(&w.stopped) == 1
+// isStopped returns true if the worker pool is stopped, false otherwise. It is
+// safe for concurrent use.
+func (p *Pool[T]) isStopped() bool {
+	return atomic.LoadUint32(&p.stopped) == 1
 }

--- a/workerpool/workerpool_doc_test.go
+++ b/workerpool/workerpool_doc_test.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 //nolint:all // This is sample code
-package worker_test
+package workerpool_test
 
 import (
 	"context"
@@ -22,15 +22,15 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/abcxyz/pkg/worker"
+	workerpool "github.com/abcxyz/pkg/workerpool"
 )
 
 func Example_sleep() {
 	ctx := context.TODO()
-	w := worker.New[*worker.Void](3)
+	pool := workerpool.New[*workerpool.Void](3)
 
 	for i := 0; i < 5; i++ {
-		if err := w.Do(ctx, func() (*worker.Void, error) {
+		if err := pool.Do(ctx, func() (*workerpool.Void, error) {
 			time.Sleep(10 * time.Millisecond)
 			return nil, nil
 		}); err != nil {
@@ -38,7 +38,7 @@ func Example_sleep() {
 		}
 	}
 
-	results, err := w.Done(ctx)
+	results, err := pool.Done(ctx)
 	if err != nil {
 		// TODO: check err
 	}
@@ -47,7 +47,7 @@ func Example_sleep() {
 
 func Example_hTTP() {
 	ctx := context.TODO()
-	w := worker.New[string](0)
+	w := workerpool.New[string](0)
 
 	urls := []string{
 		"https://apple.com",


### PR DESCRIPTION
This is a breaking change, but it's our internal package. Unfortunately we can't just alias the old package to the new package, because type aliases don't yet support generics.