### PR TITLE
workerpool: add stop-on-error functionality

### DIFF
--- a/workerpool/workerpool_doc_test.go
+++ b/workerpool/workerpool_doc_test.go
@@ -27,7 +27,9 @@ import (
 
 func Example_sleep() {
 	ctx := context.TODO()
-	pool := workerpool.New[*workerpool.Void](3)
+	pool := workerpool.New[*workerpool.Void](&workerpool.Config{
+		Concurrency: 3,
+	})
 
 	for i := 0; i < 5; i++ {
 		if err := pool.Do(ctx, func() (*workerpool.Void, error) {
@@ -47,7 +49,9 @@ func Example_sleep() {
 
 func Example_hTTP() {
 	ctx := context.TODO()
-	w := workerpool.New[string](0)
+	w := workerpool.New[string](&workerpool.Config{
+		Concurrency: 0,
+	})
 
 	urls := []string{
 		"https://apple.com",


### PR DESCRIPTION
This is a breaking API change, mostly because the "option pattern" with Go doesn't work well with generics. The Option has to carry the type signature (which is fine), but the call site requires specifying the type signature again, and it felt really bad. I'd like:

```go
pool := workerpool.New[string](3, workerpool.WithStopOnError(true))
```

but the Option also needs a type inference:

```go
pool := workerpool.New[string](3, workerpool.WithStopOnError[string](true))
```

And that would need to be repeated for each option...