### PR TITLE
test: disable cache for golangci

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -37,6 +37,7 @@ jobs:
         uses: 'actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753' # ratchet:actions/setup-go@v4
         with:
           go-version: '${{ inputs.go_version }}'
+          cache: false
 
       - name: 'Check modules'
         shell: 'bash'


### PR DESCRIPTION
It uses it's own cache: https://github.com/golangci/golangci-lint-action/issues/135