### PR TITLE
cli: add GetEnv and LookupEnv helpers

### DIFF
--- a/cli/command_completions_doc_test.go
+++ b/cli/command_completions_doc_test.go
@@ -51,7 +51,7 @@ func (c *SingCommand) PredictArgs() complete.Predictor {
 }
 
 func (c *SingCommand) Flags() *cli.FlagSet {
-	set := cli.NewFlagSet()
+	set := c.NewFlagSet()
 
 	f := set.NewSection("Song options")
 

--- a/cli/command_doc_test.go
+++ b/cli/command_doc_test.go
@@ -47,7 +47,7 @@ Usage: {{ COMMAND }} [options] MAX
 }
 
 func (c *CountCommand) Flags() *cli.FlagSet {
-	set := cli.NewFlagSet()
+	set := c.NewFlagSet()
 
 	f := set.NewSection("Number options")
 

--- a/cli/command_group_doc_test.go
+++ b/cli/command_group_doc_test.go
@@ -39,7 +39,7 @@ Usage: {{ COMMAND }} [options]
 }
 
 func (c *EatCommand) Flags() *cli.FlagSet {
-	return cli.NewFlagSet()
+	return c.NewFlagSet()
 }
 
 func (c *EatCommand) Run(ctx context.Context, args []string) error {
@@ -68,7 +68,7 @@ Usage: {{ COMMAND }} [options]
 }
 
 func (c *DrinkCommand) Flags() *cli.FlagSet {
-	return cli.NewFlagSet()
+	return c.NewFlagSet()
 }
 
 func (c *DrinkCommand) Run(ctx context.Context, args []string) error {

--- a/cli/command_persistent_flags_doc_test.go
+++ b/cli/command_persistent_flags_doc_test.go
@@ -68,7 +68,7 @@ Usage: {{ COMMAND }} [options]
 }
 
 func (c *UploadCommand) Flags() *cli.FlagSet {
-	set := cli.NewFlagSet()
+	set := c.NewFlagSet()
 	c.serverFlags.addServerFlags(set)
 	return set
 }
@@ -103,7 +103,7 @@ Usage: {{ COMMAND }} [options]
 }
 
 func (c *DownloadCommand) Flags() *cli.FlagSet {
-	set := cli.NewFlagSet()
+	set := c.NewFlagSet()
 	c.serverFlags.addServerFlags(set)
 	return set
 }

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -62,6 +62,14 @@ type Option func(fs *FlagSet) *FlagSet
 
 // WithLookupEnv defines a custom function for looking up environment variables.
 // This is mostly useful for testing.
+//
+// To bind to a CLI's lookup function:
+//
+//	func (c *CountCommand) Flags() *cli.FlagSet {
+//		set := cli.NewFlagSet(cli.WithLookupEnv(c.LookupEnv))
+//	}
+//
+// Alternatively use [BaseCommand.NewFlagSet].
 func WithLookupEnv(fn LookupEnvFunc) Option {
 	return func(fs *FlagSet) *FlagSet {
 		if fn != nil {


### PR DESCRIPTION
This adds new helpers for defining the environment. By default, they use the `os` functions. However, they can be overridden (e.g. in tests) with custom values. This also adds a new function on the Command that returns a FlagSet that is configured to use the `LookupEnv` function on the Command.