### PR TITLE
sets: introduce sets package for common set-like operations

### DIFF
--- a/sets/maps.go
+++ b/sets/maps.go
@@ -123,6 +123,11 @@ func SubtractMapKeys[K comparable, V any](maps ...map[K]V) map[K]V {
 	}
 
 	for _, m := range maps[1:] {
+		// Short-circuit: if the map is empty, there's nothing left to subtract.
+		if len(final) == 0 {
+			return final
+		}
+
 		for k := range m {
 			delete(final, k)
 		}

--- a/sets/maps.go
+++ b/sets/maps.go
@@ -53,7 +53,7 @@ func IntersectMapKeys[K comparable, V any](maps ...map[K]V) map[K]V {
 		// Short-circuit: we've already got the smallest possible intersection
 		// (empty set), so there's no point in continuing.
 		if len(final) == 0 {
-			return final
+			return make(map[K]V)
 		}
 
 		// This is us, ignore
@@ -75,9 +75,9 @@ func IntersectMapKeys[K comparable, V any](maps ...map[K]V) map[K]V {
 }
 
 // UnionMapKeys finds the union of all m, where union is defined as the
-// combination of all keys in all m. In the case of conflict, the last-provided
-// key will be in the result. It always returns an allocated map, even if the
-// union is the empty set.
+// combination of all keys in all m. In the case where duplicate keys exist
+// across maps, the value corresponding to the key in the first map is used. It
+// always returns an allocated map, even if the union is the empty set.
 //
 // It does not modify any of the given inputs, but also does not deep copy any
 // values. That means the returned map may have keys and values that point to
@@ -97,7 +97,10 @@ func UnionMapKeys[K comparable, V any](maps ...map[K]V) map[K]V {
 	// Iterate over all maps and combine elements.
 	for _, m := range maps {
 		for k, v := range m {
-			final[k] = v
+			// Only overwrite if we haven't previously seen the value.
+			if _, ok := final[k]; !ok {
+				final[k] = v
+			}
 		}
 	}
 
@@ -126,7 +129,7 @@ func SubtractMapKeys[K comparable, V any](maps ...map[K]V) map[K]V {
 	for _, m := range maps[1:] {
 		// Short-circuit: if the map is empty, there's nothing left to subtract.
 		if len(final) == 0 {
-			return final
+			return make(map[K]V)
 		}
 
 		for k := range m {

--- a/sets/maps.go
+++ b/sets/maps.go
@@ -15,8 +15,9 @@
 package sets
 
 // IntersectMapKeys finds the intersection of all m keys, where intersection is
-// defined as keys that exist in all m. It always returns an allocated map, even
-// if the intersection is the empty set.
+// defined as keys that exist in all m. In the case where duplicate keys exist
+// across maps, the value corresponding to the key in the first map is used. It
+// always returns an allocated map, even if the intersection is the empty set.
 //
 // It does not modify any of the given inputs, but also does not deep copy any
 // values. That means the returned map may have keys and values that point to

--- a/sets/maps.go
+++ b/sets/maps.go
@@ -1,0 +1,132 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sets
+
+// IntersectMapKeys finds the intersection of all m keys, where intersection is
+// defined as keys that exist in all m. It always returns an allocated map, even
+// if the intersection is the empty set.
+//
+// It does not modify any of the given inputs, but also does not deep copy any
+// values. That means the returned map may have keys and values that point to
+// the same objects as in the original map.
+func IntersectMapKeys[K comparable, V any](maps ...map[K]V) map[K]V {
+	if len(maps) == 0 {
+		return make(map[K]V)
+	}
+
+	// Pre-compute the maximum possible allocation to minimize allocs. Here we
+	// find the map with the least number of elements and allocate a map of that
+	// size, since we know that is the maximum possible intersection size.
+	var smallestIdx int
+	for i, m := range maps {
+		// Short-circuit: if any of the maps are the empty set, we know the
+		// intersection is the empty set.
+		if len(m) == 0 {
+			return make(map[K]V)
+		}
+
+		if len(m) < len(maps[smallestIdx]) {
+			smallestIdx = i
+		}
+	}
+	smallestMap := maps[smallestIdx]
+	final := make(map[K]V, len(smallestMap))
+	for k, v := range smallestMap {
+		final[k] = v
+	}
+
+	// Compute the intersection.
+	for i, m := range maps {
+		// Short-circuit: we've already got the smallest possible intersection
+		// (empty set), so there's no point in continuing.
+		if len(final) == 0 {
+			return final
+		}
+
+		// This is us, ignore
+		if i == smallestIdx {
+			continue
+		}
+
+		// For each key in our smallest set, check if the key exists in the current
+		// map. If it does not, remove it from the map since it's not part of the
+		// intersection.
+		for k := range final {
+			if _, ok := m[k]; !ok {
+				delete(final, k)
+			}
+		}
+	}
+
+	return final
+}
+
+// UnionMapKeys finds the union of all m, where union is defined as the
+// combination of all keys in all m. In the case of conflict, the last-provided
+// key will be in the result. It always returns an allocated map, even if the
+// union is the empty set.
+//
+// It does not modify any of the given inputs, but also does not deep copy any
+// values. That means the returned map may have keys and values that point to
+// the same objects as in the original map.
+func UnionMapKeys[K comparable, V any](maps ...map[K]V) map[K]V {
+	if len(maps) == 0 {
+		return make(map[K]V)
+	}
+
+	// Pre-compute the maximum possible allocation to minimize allocs.
+	var alloc int
+	for _, m := range maps {
+		alloc += len(m)
+	}
+	final := make(map[K]V, alloc)
+
+	// Iterate over all maps and combine elements.
+	for _, m := range maps {
+		for k, v := range m {
+			final[k] = v
+		}
+	}
+
+	return final
+}
+
+// SubtractMapKeys finds the differece (subtraction), where difference is
+// defined as the removal of all keys from m0 that exist in mn. It always
+// returns an allocated map, even if the difference is the empty set.
+//
+// It does not modify any of the given inputs, but also does not deep copy any
+// values. That means the returned map may have keys and values that point to
+// the same objects as in the original map.
+func SubtractMapKeys[K comparable, V any](maps ...map[K]V) map[K]V {
+	if len(maps) == 0 {
+		return make(map[K]V)
+	}
+
+	// Pre-compute the maximum possible allocation to minimize allocs.
+	initialMap := maps[0]
+	final := make(map[K]V, len(initialMap))
+	for k, v := range initialMap {
+		final[k] = v
+	}
+
+	for _, m := range maps[1:] {
+		for k := range m {
+			delete(final, k)
+		}
+	}
+
+	return final
+}

--- a/sets/maps_test.go
+++ b/sets/maps_test.go
@@ -72,6 +72,18 @@ func TestIntersectMapKeys(t *testing.T) {
 			},
 		},
 		{
+			name: "first_overwrites",
+			maps: []map[string]string{
+				{"foo": "bar", "zip": "zap", "fruit": "banana"},
+				{"foo": "bar2", "zip": "zap", "fruit": "banana"},
+				{"foo": "bar", "zip": "zap"},
+				{"foo": "bar"},
+			},
+			exp: map[string]string{
+				"foo": "bar",
+			},
+		},
+		{
 			name: "all",
 			maps: []map[string]string{
 				{"foo": "bar", "zip": "zap", "fruit": "banana"},
@@ -154,14 +166,14 @@ func TestUnionMapKeys(t *testing.T) {
 			},
 		},
 		{
-			name: "last_overwrites",
+			name: "first_overwrites",
 			maps: []map[string]string{
 				{"foo": "bar"},
 				{"zip": "zap"},
 				{"foo": "bar2"},
 			},
 			exp: map[string]string{
-				"foo": "bar2",
+				"foo": "bar",
 				"zip": "zap",
 			},
 		},

--- a/sets/maps_test.go
+++ b/sets/maps_test.go
@@ -1,0 +1,314 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sets
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestIntersectMapKeys(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		maps []map[string]string
+		exp  map[string]string
+	}{
+		{
+			name: "nil_maps",
+			maps: nil,
+			exp:  map[string]string{},
+		},
+		{
+			name: "empty_maps",
+			maps: []map[string]string{
+				{"foo": "bar", "zip": "zap", "fruit": "banana"},
+				nil,
+				{"foo": "bar", "zip": "zap"},
+				{},
+			},
+			exp: map[string]string{},
+		},
+		{
+			name: "none",
+			maps: []map[string]string{
+				{"foo": "bar"},
+				{"zip": "zap"},
+			},
+			exp: map[string]string{},
+		},
+		{
+			name: "one",
+			maps: []map[string]string{
+				{"foo": "bar"},
+				{"foo": "bar"},
+			},
+			exp: map[string]string{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "many",
+			maps: []map[string]string{
+				{"foo": "bar", "zip": "zap"},
+				{"foo": "bar", "zip": "zap", "fruit": "banana"},
+			},
+			exp: map[string]string{
+				"foo": "bar", "zip": "zap",
+			},
+		},
+		{
+			name: "all",
+			maps: []map[string]string{
+				{"foo": "bar", "zip": "zap", "fruit": "banana"},
+				{"foo": "bar", "zip": "zap", "fruit": "banana"},
+				{"foo": "bar", "zip": "zap"},
+				{"foo": "bar"},
+			},
+			exp: map[string]string{
+				"foo": "bar",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Get a copy so we can verify the input maps were not modified.
+			mapsCopy := testDeepCopyMaps(t, tc.maps)
+
+			got := IntersectMapKeys(tc.maps...)
+			if diff := cmp.Diff(tc.exp, got); diff != "" {
+				t.Errorf("incorrect insersection (-want/+got):\n%s", diff)
+			}
+
+			// Ensure the maps were not modified.
+			if diff := cmp.Diff(mapsCopy, tc.maps); diff != "" {
+				t.Errorf("insersection modified map (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestUnionMapKeys(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		maps []map[string]string
+		exp  map[string]string
+	}{
+		{
+			name: "nil_maps",
+			maps: nil,
+			exp:  map[string]string{},
+		},
+		{
+			name: "empty_maps",
+			maps: []map[string]string{
+				{"foo": "bar"},
+				nil,
+				{"zip": "zap"},
+				{},
+			},
+			exp: map[string]string{
+				"foo": "bar",
+				"zip": "zap",
+			},
+		},
+		{
+			name: "one",
+			maps: []map[string]string{
+				{"foo": "bar"},
+			},
+			exp: map[string]string{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "many",
+			maps: []map[string]string{
+				{"foo": "bar"},
+				{"zip": "zap"},
+			},
+			exp: map[string]string{
+				"foo": "bar",
+				"zip": "zap",
+			},
+		},
+		{
+			name: "last_overwrites",
+			maps: []map[string]string{
+				{"foo": "bar"},
+				{"zip": "zap"},
+				{"foo": "bar2"},
+			},
+			exp: map[string]string{
+				"foo": "bar2",
+				"zip": "zap",
+			},
+		},
+		{
+			name: "all",
+			maps: []map[string]string{
+				{"foo": "bar", "zip": "zap", "fruit": "banana"},
+				{"foo": "bar", "zip": "zap", "fruit": "banana"},
+				{"foo": "bar", "zip": "zap"},
+				{"foo": "bar"},
+			},
+			exp: map[string]string{
+				"foo":   "bar",
+				"zip":   "zap",
+				"fruit": "banana",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Get a copy so we can verify the input maps were not modified.
+			mapsCopy := testDeepCopyMaps(t, tc.maps)
+
+			got := UnionMapKeys(tc.maps...)
+			if diff := cmp.Diff(tc.exp, got); diff != "" {
+				t.Errorf("incorrect insersection (-want/+got):\n%s", diff)
+			}
+
+			// Ensure the maps were not modified.
+			if diff := cmp.Diff(mapsCopy, tc.maps); diff != "" {
+				t.Errorf("insersection modified map (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSubtractMapKeys(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		maps []map[string]string
+		exp  map[string]string
+	}{
+		{
+			name: "nil_maps",
+			maps: nil,
+			exp:  map[string]string{},
+		},
+		{
+			name: "empty_maps",
+			maps: []map[string]string{
+				{"foo": "bar"},
+				nil,
+				{"zip": "zap"},
+				{},
+			},
+			exp: map[string]string{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "one",
+			maps: []map[string]string{
+				{"foo": "bar"},
+			},
+			exp: map[string]string{
+				"foo": "bar",
+			},
+		},
+		{
+			name: "many",
+			maps: []map[string]string{
+				{"foo": "bar"},
+				{"foo": "bar", "zip": "zap"},
+			},
+			exp: map[string]string{},
+		},
+		{
+			name: "remaining",
+			maps: []map[string]string{
+				{"foo": "bar", "zip": "zap", "fruit": "banana"},
+				{"zip": "zap"},
+			},
+			exp: map[string]string{
+				"foo":   "bar",
+				"fruit": "banana",
+			},
+		},
+		{
+			name: "all",
+			maps: []map[string]string{
+				{"foo": "bar", "zip": "zap", "fruit": "banana"},
+				{"foo": "bar", "zip": "zap"},
+				{"fruit": "banana"},
+				{"fruit": "banana"},
+			},
+			exp: map[string]string{},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Get a copy so we can verify the input maps were not modified.
+			mapsCopy := testDeepCopyMaps(t, tc.maps)
+
+			got := SubtractMapKeys(tc.maps...)
+			if diff := cmp.Diff(tc.exp, got); diff != "" {
+				t.Errorf("incorrect insersection (-want/+got):\n%s", diff)
+			}
+
+			// Ensure the maps were not modified.
+			if diff := cmp.Diff(mapsCopy, tc.maps); diff != "" {
+				t.Errorf("insersection modified map (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func testDeepCopyMaps[K comparable, V any](tb testing.TB, maps []map[K]V) []map[K]V {
+	tb.Helper()
+
+	if len(maps) == 0 {
+		return nil
+	}
+
+	final := make([]map[K]V, len(maps))
+	for i, m := range maps {
+		if m == nil {
+			final[i] = nil
+			continue
+		}
+
+		inner := make(map[K]V, len(m))
+		for k, v := range m {
+			inner[k] = v
+		}
+		final[i] = inner
+	}
+	return final
+}

--- a/sets/sets.go
+++ b/sets/sets.go
@@ -1,0 +1,16 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sets defines efficient operations for common set operations.
+package sets

--- a/sets/slices.go
+++ b/sets/slices.go
@@ -81,7 +81,7 @@ func IntersectStable[T comparable](slices ...[]T) []T {
 		// Short-circuit: if our intersection is already the empty set, we can
 		// return now.
 		if len(final) == 0 {
-			return final
+			return []T{}
 		}
 
 		var i int

--- a/sets/slices.go
+++ b/sets/slices.go
@@ -1,0 +1,196 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sets
+
+// Intersect finds the intersection of all slices, where intersection is defined
+// as elements that exist in all slices. The elements in the returned slice will
+// be in an undefined order - use [IntersectStable] to trade efficiency for
+// ordering. Duplicate elements are removed. This function always returns an
+// allocated slice, even if the intersection is the empty set.
+//
+// It does not modify any of the given slices, but also does not deep copy any
+// values. That means the returned slice may have elements that point to the
+// same objects as in the original slice.
+func Intersect[T comparable](slices ...[]T) []T {
+	if len(slices) == 0 {
+		return []T{}
+	}
+
+	maps := make([]map[T]struct{}, len(slices))
+	for i, s := range slices {
+		// Short-circuit: if any of the slices are the empty set, we know the
+		// intersection is the empty set.
+		if len(s) == 0 {
+			return []T{}
+		}
+
+		m := make(map[T]struct{}, len(s))
+		for _, v := range s {
+			m[v] = struct{}{}
+		}
+		maps[i] = m
+	}
+
+	result := IntersectMapKeys(maps...)
+	final := make([]T, 0, len(result))
+	for k := range result {
+		final = append(final, k)
+	}
+	return final
+}
+
+// IntersectStable has the same invariants [Intersect], except it preserves the
+// relative order of elements in the intersection. This function has a
+// comparatively higher runtime complexity than [Intersect].
+func IntersectStable[T comparable](slices ...[]T) []T {
+	if len(slices) == 0 {
+		return []T{}
+	}
+
+	// Make a copy of the first slice; we're going to gradually remove elements.
+	final := append([]T{}, slices[0]...)
+
+	// Remove duplicates
+	finalSeen := make(map[T]struct{}, len(final))
+	var i int
+	for _, v := range final {
+		if _, ok := finalSeen[v]; !ok {
+			finalSeen[v] = struct{}{}
+			final[i] = v
+			i++
+		}
+	}
+	for j := i; j < len(final); j++ {
+		final[j] = *new(T)
+	}
+	final = final[:i:len(final)]
+
+	for _, s := range slices[1:] {
+		// Short-circuit: if our intersection is already the empty set, we can
+		// return now.
+		if len(final) == 0 {
+			return final
+		}
+
+		var i int
+		for _, v := range final {
+			if sliceContains(s, v) {
+				final[i] = v
+				i++
+			}
+		}
+		// Delete unused elements, nil out unused space so we don't leak.
+		for j := i; j < len(final); j++ {
+			final[j] = *new(T)
+		}
+		final = final[:i:len(final)]
+	}
+	return final
+}
+
+// Union finds the union of all slices, where union is defined as the
+// combination of all elements in all slices. The elements are returned in the
+// order in which they first appear in the slices. Duplicate elements are
+// removed. This function always returns an allocated slice, even if the union
+// is the empty set.
+//
+// It does not modify any of the given slices, but also does not deep copy any
+// values. That means the returned slice may have elements that point to the
+// same objects as in the original slice.
+func Union[T comparable](slices ...[]T) []T {
+	if len(slices) == 0 {
+		return []T{}
+	}
+
+	// Pre-compute the maximum possible allocation to minimize allocs.
+	var alloc int
+	for _, s := range slices {
+		alloc += len(s)
+	}
+	final := make([]T, 0, alloc)
+	seen := make(map[T]struct{}, alloc)
+
+	// Iterate over all maps and combine elements.
+	for _, s := range slices {
+		for _, v := range s {
+			if _, ok := seen[v]; ok {
+				// We already saw this element
+				continue
+			}
+
+			final = append(final, v)
+			seen[v] = struct{}{}
+		}
+	}
+	return final[:len(final):len(final)]
+}
+
+// Subtract finds the differece (subtraction), where difference is defined as
+// the removal of all elements from s0 that exist in sn. The elements are
+// returned in the order in which they appeared in s0. This function always
+// returns an allocated slice, even if the difference is the empty set.
+//
+// All duplicate elements that match a subtraction are removed. Duplicate
+// elements that do not match a subtraction are preserved.
+//
+// It does not modify any of the given slices, but also does not deep copy any
+// values. That means the returned slice may have elements that point to the
+// same objects as in the original slice.
+func Subtract[T comparable](slices ...[]T) []T {
+	if len(slices) == 0 {
+		return []T{}
+	}
+
+	// Make a copy of the first slice; we're going to gradually remove elements.
+	final := append([]T{}, slices[0]...)
+
+	var alloc int
+	for _, s := range slices[1:] {
+		alloc += len(s)
+	}
+	toDelete := make(map[T]struct{}, alloc)
+	for _, s := range slices[1:] {
+		for _, k := range s {
+			toDelete[k] = struct{}{}
+		}
+	}
+
+	var i int
+	for _, v := range final {
+		if _, ok := toDelete[v]; !ok {
+			final[i] = v
+			i++
+		}
+	}
+	// Delete unused elements, nil out unused space so we don't leak.
+	for j := i; j < len(final); j++ {
+		final[j] = *new(T)
+	}
+	final = final[:i:len(final)]
+	return final
+}
+
+func sliceIndex[T comparable](haystack []T, needle T) int {
+	for i, v := range haystack {
+		if v == needle {
+			return i
+		}
+	}
+	return -1
+}
+
+func sliceContains[T comparable](haystack []T, needle T) bool {
+	return sliceIndex(haystack, needle) != -1
+}

--- a/sets/slices_test.go
+++ b/sets/slices_test.go
@@ -104,6 +104,11 @@ func TestIntersect(t *testing.T) {
 				t.Errorf("incorrect insersection (-want/+got):\n%s", diff)
 			}
 
+			// Ensure we freed up as much memory as possible.
+			if c, l := cap(got), len(got); c != l {
+				t.Errorf("expected cap(%d) to equal len(%d)", c, l)
+			}
+
 			// Ensure the slices were not modified.
 			if diff := cmp.Diff(slicesCopy, tc.slices); diff != "" {
 				t.Errorf("insersection modified slice (-want/+got):\n%s", diff)
@@ -191,6 +196,11 @@ func TestIntersectStable(t *testing.T) {
 			got := IntersectStable(tc.slices...)
 			if diff := cmp.Diff(tc.exp, got); diff != "" {
 				t.Errorf("incorrect insersection (-want/+got):\n%s", diff)
+			}
+
+			// Ensure we freed up as much memory as possible.
+			if c, l := cap(got), len(got); c != l {
+				t.Errorf("expected cap(%d) to equal len(%d)", c, l)
 			}
 
 			// Ensure the slices were not modified.
@@ -359,6 +369,11 @@ func TestSubtract(t *testing.T) {
 			got := Subtract(tc.slices...)
 			if diff := cmp.Diff(tc.exp, got); diff != "" {
 				t.Errorf("incorrect insersection (-want/+got):\n%s", diff)
+			}
+
+			// Ensure we freed up as much memory as possible.
+			if c, l := cap(got), len(got); c != l {
+				t.Errorf("expected cap(%d) to equal len(%d)", c, l)
 			}
 
 			// Ensure the slices were not modified.

--- a/sets/slices_test.go
+++ b/sets/slices_test.go
@@ -1,0 +1,388 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sets
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+)
+
+func TestIntersect(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		slices [][]string
+		exp    []string
+	}{
+		{
+			name:   "nil_slices",
+			slices: nil,
+			exp:    []string{},
+		},
+		{
+			name: "empty_slices",
+			slices: [][]string{
+				{"foo", "bar", "zip", "zap"},
+				nil,
+				{"foo", "bar"},
+				{},
+			},
+			exp: []string{},
+		},
+		{
+			name: "none",
+			slices: [][]string{
+				{"foo", "bar"},
+				{"zip", "zap"},
+			},
+			exp: []string{},
+		},
+		{
+			name: "one",
+			slices: [][]string{
+				{"foo", "bar"},
+				{"foo", "baz"},
+			},
+			exp: []string{"foo"},
+		},
+		{
+			name: "many",
+			slices: [][]string{
+				{"foo", "bar", "zip", "zap"},
+				{"foo", "bar", "zip", "zap", "fruit", "banana"},
+			},
+			exp: []string{"foo", "bar", "zip", "zap"},
+		},
+		{
+			name: "all",
+			slices: [][]string{
+				{"foo", "bar", "zip", "zap", "fruit", "banana"},
+				{"foo", "bar", "zip", "zap", "fruit", "banana"},
+				{"foo", "bar", "zip", "zap"},
+				{"foo", "bar"},
+			},
+			exp: []string{"foo", "bar"},
+		},
+		{
+			name: "duplicates",
+			slices: [][]string{
+				{"foo", "foo", "foo", "bar"},
+				{"foo", "bar"},
+			},
+			exp: []string{"foo", "bar"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Get a copy so we can verify the input slices were not modified.
+			slicesCopy := testDeepCopySlices(t, tc.slices)
+
+			got := Intersect(tc.slices...)
+			if diff := cmp.Diff(tc.exp, got, cmpopts.SortSlices(func(x, y string) bool {
+				return x < y
+			})); diff != "" {
+				t.Errorf("incorrect insersection (-want/+got):\n%s", diff)
+			}
+
+			// Ensure the slices were not modified.
+			if diff := cmp.Diff(slicesCopy, tc.slices); diff != "" {
+				t.Errorf("insersection modified slice (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestIntersectStable(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		slices [][]string
+		exp    []string
+	}{
+		{
+			name:   "nil_slices",
+			slices: nil,
+			exp:    []string{},
+		},
+		{
+			name: "empty_slices",
+			slices: [][]string{
+				{"foo", "bar", "zip", "zap"},
+				nil,
+				{"foo", "bar"},
+				{},
+			},
+			exp: []string{},
+		},
+		{
+			name: "none",
+			slices: [][]string{
+				{"foo", "bar"},
+				{"zip", "zap"},
+			},
+			exp: []string{},
+		},
+		{
+			name: "one",
+			slices: [][]string{
+				{"foo", "bar"},
+				{"foo", "baz"},
+			},
+			exp: []string{"foo"},
+		},
+		{
+			name: "many",
+			slices: [][]string{
+				{"foo", "bar", "zip", "zap", "zonk", "zink", "apple", "banana"},
+				{"apple", "bar", "foo", "bar", "zip", "zap", "apple", "fruit", "banana", "zink", "zonk", "apple"},
+			},
+			exp: []string{"foo", "bar", "zip", "zap", "zonk", "zink", "apple", "banana"},
+		},
+		{
+			name: "all",
+			slices: [][]string{
+				{"foo", "bar", "zip", "zap", "fruit", "banana"},
+				{"foo", "bar", "zip", "zap", "fruit", "banana"},
+				{"foo", "bar", "zip", "zap"},
+				{"foo", "bar"},
+			},
+			exp: []string{"foo", "bar"},
+		},
+		{
+			name: "duplicates",
+			slices: [][]string{
+				{"foo", "foo", "foo", "bar"},
+				{"foo", "bar"},
+			},
+			exp: []string{"foo", "bar"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Get a copy so we can verify the input slices were not modified.
+			slicesCopy := testDeepCopySlices(t, tc.slices)
+
+			got := IntersectStable(tc.slices...)
+			if diff := cmp.Diff(tc.exp, got); diff != "" {
+				t.Errorf("incorrect insersection (-want/+got):\n%s", diff)
+			}
+
+			// Ensure the slices were not modified.
+			if diff := cmp.Diff(slicesCopy, tc.slices); diff != "" {
+				t.Errorf("insersection modified slice (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestUnion(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		slices [][]string
+		exp    []string
+	}{
+		{
+			name:   "nil_slices",
+			slices: nil,
+			exp:    []string{},
+		},
+		{
+			name: "empty_slices",
+			slices: [][]string{
+				{"foo"},
+				nil,
+				{"bar"},
+				{},
+			},
+			exp: []string{"foo", "bar"},
+		},
+		{
+			name: "one",
+			slices: [][]string{
+				{"foo", "bar"},
+			},
+			exp: []string{"foo", "bar"},
+		},
+		{
+			name: "many",
+			slices: [][]string{
+				{"foo", "bar"},
+				{"zip", "zap"},
+			},
+			exp: []string{"foo", "bar", "zip", "zap"},
+		},
+		{
+			name: "all",
+			slices: [][]string{
+				{"foo", "bar", "zip", "zap"},
+				{"foo", "bar"},
+				{"apple", "banana"},
+			},
+			exp: []string{"foo", "bar", "zip", "zap", "apple", "banana"},
+		},
+		{
+			name: "duplicates",
+			slices: [][]string{
+				{"bar", "foo", "foo", "foo", "bar"},
+				{"foo", "bar"},
+			},
+			exp: []string{"bar", "foo"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Get a copy so we can verify the input slices were not modified.
+			slicesCopy := testDeepCopySlices(t, tc.slices)
+
+			got := Union(tc.slices...)
+			if diff := cmp.Diff(tc.exp, got); diff != "" {
+				t.Errorf("incorrect insersection (-want/+got):\n%s", diff)
+			}
+
+			// Ensure the slices were not modified.
+			if diff := cmp.Diff(slicesCopy, tc.slices); diff != "" {
+				t.Errorf("insersection modified slice (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestSubtract(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		slices [][]string
+		exp    []string
+	}{
+		{
+			name:   "nil_slices",
+			slices: nil,
+			exp:    []string{},
+		},
+		{
+			name: "empty_slices",
+			slices: [][]string{
+				{"foo", "bar"},
+				nil,
+				{"zip", "zap"},
+				{},
+			},
+			exp: []string{"foo", "bar"},
+		},
+		{
+			name: "one",
+			slices: [][]string{
+				{"foo"},
+				{"foo"},
+			},
+			exp: []string{},
+		},
+		{
+			name: "many",
+			slices: [][]string{
+				{"foo", "bar"},
+				{"foo", "bar", "zip", "zap"},
+			},
+			exp: []string{},
+		},
+		{
+			name: "remaining",
+			slices: [][]string{
+				{"foo", "bar", "zip", "zap", "fruit", "banana"},
+				{"zip", "zap"},
+			},
+			exp: []string{"foo", "bar", "fruit", "banana"},
+		},
+		{
+			name: "all",
+			slices: [][]string{
+				{"foo", "bar", "zip", "zap", "fruit", "banana"},
+				{"foo", "bar", "zip", "zap"},
+				{"fruit", "banana"},
+				{"fruit", "banana"},
+			},
+			exp: []string{},
+		},
+		{
+			name: "duplicates",
+			slices: [][]string{
+				{"bar", "foo", "foo", "foo", "bar"},
+				{"bar"},
+			},
+			exp: []string{"foo", "foo", "foo"},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Get a copy so we can verify the input slices were not modified.
+			slicesCopy := testDeepCopySlices(t, tc.slices)
+
+			got := Subtract(tc.slices...)
+			if diff := cmp.Diff(tc.exp, got); diff != "" {
+				t.Errorf("incorrect insersection (-want/+got):\n%s", diff)
+			}
+
+			// Ensure the slices were not modified.
+			if diff := cmp.Diff(slicesCopy, tc.slices); diff != "" {
+				t.Errorf("insersection modified slice (-want/+got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func testDeepCopySlices[T comparable](tb testing.TB, slices [][]T) [][]T {
+	tb.Helper()
+
+	if len(slices) == 0 {
+		return nil
+	}
+
+	final := make([][]T, len(slices))
+	for i, s := range slices {
+		if s == nil {
+			final[i] = nil
+			continue
+		}
+		final[i] = append([]T{}, s...)
+	}
+	return final
+}


### PR DESCRIPTION
This introduces some library functions that are not present in `exp/slices` and `exp/maps` today, notably set intersection, union, and subtraction operations.

The package exposes both `slice` and `map` variants, but the `map` functions are named `*MapKeys` to emphasize that set operations are performed on the keys as opposed to the values.