### PR TITLE
Support back-and-forth dialogs in Prompt() tests

### DIFF
--- a/cli/command.go
+++ b/cli/command.go
@@ -280,7 +280,7 @@ func (c *BaseCommand) Hidden() bool {
 // up to 64k bytes. If there's an input stream (e.g. a pipe), it will read the
 // pipe.
 //
-// The prompt will be printed to stdout if any of these cases is true:
+// The prompt will be printed to c.Stdout() if any of these cases is true:
 //   - the terminal is a TTY (for real user interaction)
 //   - c.StdIn(), c.Stdout(), and c.Stderr() came from io.Pipe() (for unit-testing back-and-forth dialog)
 //

--- a/cli/command.go
+++ b/cli/command.go
@@ -287,7 +287,7 @@ func (c *BaseCommand) Hidden() bool {
 // It will fail if stdin pipe and the terminal is not a tty. If the context is canceled,
 // this function leaves the c.Stdin in a bad state.
 func (c *BaseCommand) Prompt(ctx context.Context, msg string, args ...any) (string, error) {
-	_, stdoutIsPipe := c.Stdout().(*io.PipeWriter) // true if this is a unit test
+	_, stdoutIsPipe := c.Stdout().(*io.PipeWriter) // we expect unit tests to use PipeWriter if they want to see prompts
 
 	stdinIsTTY := c.Stdin() == os.Stdin && isatty.IsTerminal(os.Stdin.Fd())
 

--- a/cli/command_test.go
+++ b/cli/command_test.go
@@ -441,6 +441,8 @@ func TestBaseCommand_Prompt_Dialog(t *testing.T) {
 }
 
 func TestShouldPrompt_Pipe(t *testing.T) {
+	t.Parallel()
+
 	stdinReader, _ := io.Pipe()
 	_, stdoutWriter := io.Pipe()
 	_, stderrWriter := io.Pipe()
@@ -451,6 +453,8 @@ func TestShouldPrompt_Pipe(t *testing.T) {
 }
 
 func TestShouldPrompt_ByteBuffer(t *testing.T) {
+	t.Parallel()
+
 	if shouldPrompt(&bytes.Buffer{}, &bytes.Buffer{}, &bytes.Buffer{}) {
 		t.Fatal("shouldPrompt() got true, want false, when passed a Buffer")
 	}

--- a/cli/command_test.go
+++ b/cli/command_test.go
@@ -500,6 +500,7 @@ func writeWithTimeout(tb testing.TB, w io.Writer, msg string) {
 
 	errCh := make(chan error)
 	go func() {
+		defer close(errCh)
 		_, err := w.Write([]byte(msg))
 		errCh <- err
 	}()

--- a/cli/command_test.go
+++ b/cli/command_test.go
@@ -400,17 +400,17 @@ func TestBaseCommand_Prompt_Dialog(t *testing.T) {
 
 	ctx := context.Background()
 	errCh := make(chan error)
-	var color, iceCream string
+	var gotColor, gotIceCream string
 	go func() {
 		defer close(errCh)
 		var err error
-		color, err = cmd.Prompt(ctx, "Please enter a color: ")
+		gotColor, err = cmd.Prompt(ctx, "Please enter a color: ")
 		if err != nil {
 			errCh <- err
 			return
 		}
 
-		iceCream, err = cmd.Prompt(ctx, "Please enter a flavor of ice cream: ")
+		gotIceCream, err = cmd.Prompt(ctx, "Please enter a flavor of ice cream: ")
 		if err != nil {
 			errCh <- err
 			return
@@ -430,12 +430,13 @@ func TestBaseCommand_Prompt_Dialog(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for background Prompt() goroutine to exit")
 	}
-
-	if color != "blue" {
-		t.Fatalf(`got color %q, wanted "blue"`, color)
+	const wantColor = "blue"
+	if gotColor != wantColor {
+		t.Fatalf(`got color %q, wanted %q`, gotColor, wantColor)
 	}
-	if iceCream != "mint chip" {
-		t.Fatalf(`got iceCream %q, wanted "mint chip"`, iceCream)
+	const wantIceCream = "mint chip"
+	if gotIceCream != wantIceCream {
+		t.Fatalf(`got iceCream %q, wanted %q`, gotIceCream, wantIceCream)
 	}
 }
 

--- a/cli/command_test.go
+++ b/cli/command_test.go
@@ -385,6 +385,8 @@ func TestBaseCommand_Prompt_Cancels(t *testing.T) {
 
 // Tests back-and-forth conversation using Prompt().
 func TestBaseCommand_Prompt_Dialog(t *testing.T) {
+	t.Parallel()
+
 	cmd := &RootCommand{}
 
 	stdinReader, stdinWriter := io.Pipe()
@@ -438,6 +440,8 @@ func TestBaseCommand_Prompt_Dialog(t *testing.T) {
 // that read fails or the returned string doesn't contain wantSubStr. May leak a
 // goroutine on timeout.
 func readWithTimeout(t *testing.T, r io.Reader, wantSubstr string) {
+	t.Helper()
+
 	t.Logf("readWith starting with %q", wantSubstr)
 
 	var got string
@@ -470,6 +474,8 @@ func readWithTimeout(t *testing.T, r io.Reader, wantSubstr string) {
 // writeWithTimeout does a single write to the given writer. It calls Fatal
 // if that read dosen't contain wantSubStr. May leak a goroutine on timeout.
 func writeWithTimeout(t *testing.T, w io.Writer, msg string) {
+	t.Helper()
+
 	t.Logf("writeWithTimeout starting with %q", msg)
 
 	errCh := make(chan error)


### PR DESCRIPTION
Why? In the abc CLI we want to test a function that does multiple rounds of back-and-forth dialog with the user. Currently, this isn't possible, because prompts don't appear in a test environment. `Prompt()`
doesn't write to stdout when stdout is a `*bytes.Buffer` (as created by `BaseCommand.Pipe()`).

How do we do this? We add a type-assertion to check is stdout is a `*io.PipeWriter.` If so, we assume that it's appropriate to print a prompt. Tests that want to see prompt messages can just use `io.Pipe`.

Also, we add  a new test`TestBaseCommand_Prompt_Dialog`, which demonstrates how to write a kind of "conversational" tests using `Prompt()`.

*Alternative considered*: rather than checking for stdout to be a `*io.PipeWriter`, check that it implements some special interface like `type promptable interface { promptable() }`. Callers would then have to wrap their `io.Writer` in a type that implements that interface to indicate their willingness to receive promopts. This would be more flexible, but also more verbose and harder to understand.