### PR TITLE
fix: terraform-linter honors import blocks

### DIFF
--- a/internal/tools/terraformlinter/terraform_linter.go
+++ b/internal/tools/terraformlinter/terraform_linter.go
@@ -34,6 +34,7 @@ const (
 	tokenTypeVariable = "variable"
 	tokenTypeOutput   = "output"
 	tokenTypeLocals   = "locals"
+	tokenTypeImport   = "import"
 )
 
 // List of valid extensions that can be linted.
@@ -188,7 +189,8 @@ func findViolations(content []byte, path string) ([]*ViolationInstance, error) {
 				contents == tokenTypeModule ||
 				contents == tokenTypeOutput ||
 				contents == tokenTypeVariable ||
-				contents == tokenTypeLocals) {
+				contents == tokenTypeLocals ||
+				contents == tokenTypeImport) {
 			inBlock = true
 			start = idx
 			depth = 0

--- a/internal/tools/terraformlinter/terraform_linter_test.go
+++ b/internal/tools/terraformlinter/terraform_linter_test.go
@@ -695,6 +695,16 @@ func TestTerraformLinter_FindViolations(t *testing.T) {
 			`,
 			wantError: false,
 		},
+		{
+			name: "allows_import_blocks",
+			content: `
+			import {
+			  to = module.project.google_project.default
+			  id = "project-id-with-hyphens"
+			}
+			`,
+			wantError: false,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Terraform added a new `import` block that should be supported by our linter. Previously it would throw and error if values contained a hyphen but that should be allowed.

