### PR TITLE
Re-disable caching in Go CI

### DIFF
--- a/.github/actions/terraform-linter/action.yml
+++ b/.github/actions/terraform-linter/action.yml
@@ -32,6 +32,7 @@ runs:
       uses: 'actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753' # ratchet:actions/setup-go@v4
       with:
         go-version: '1.20'
+        cache: false
 
     - id: 'run-linter'
       shell: 'bash'

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -82,6 +82,7 @@ jobs:
         uses: 'actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753' # ratchet:actions/setup-go@v4
         with:
           go-version: '${{ inputs.go_version }}'
+          cache: false
 
       - name: 'Lint (download default configuration)'
         id: 'load-default-config'
@@ -109,6 +110,7 @@ jobs:
         with:
           args: |-
             --config "${{ steps.load-default-config.outputs.output-file }}"
+          skip-cache: true
           version: '${{ inputs.golangci_lint_version }}'
           working-directory: '${{ inputs.directory }}'
 
@@ -116,5 +118,6 @@ jobs:
         if: '${{ hashFiles(''.golangci.yml'', ''.golangci.yaml'') != '''' }}'
         uses: 'golangci/golangci-lint-action@639cd343e1d3b897ff35927a75193d57cfcba299' # ratchet:golangci/golangci-lint-action@v3
         with:
+          skip-cache: true
           version: '${{ inputs.golangci_lint_version }}'
           working-directory: '${{ inputs.directory }}'

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -67,6 +67,7 @@ jobs:
         uses: 'actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753' # ratchet:actions/setup-go@v4
         with:
           go-version: '${{ inputs.go_version }}'
+          cache: false
 
       - name: 'Test'
         shell: 'bash'


### PR DESCRIPTION
This appears to be breaking golangci and a few other things. We don't get a ton of benefit from these caches.