### PR TITLE
fix: specific functions for github access tokens

### DIFF
--- a/githubapp/githubapp.go
+++ b/githubapp/githubapp.go
@@ -211,6 +211,10 @@ func (g *GitHubApp) generateAppJWT() ([]byte, error) {
 // access token for this application installation with the requested
 // permissions and repositories.
 func (g *GitHubApp) AccessToken(ctx context.Context, request *TokenRequest) (string, error) {
+	if request.Repositories == nil {
+		return "", fmt.Errorf("requested repositories cannot be nil, did you mean to use AccessTokenAllRepos to request all repos?")
+	}
+
 	requestJSON, err := json.Marshal(request)
 	if err != nil {
 		return "", fmt.Errorf("error marshalling request data: %w", err)

--- a/githubapp/githubapp.go
+++ b/githubapp/githubapp.go
@@ -115,8 +115,16 @@ func NewConfig(appID, installationID string, privateKey *rsa.PrivateKey, opts ..
 // requested permissions / scopes that are requested when generating a
 // new installation access token.
 type TokenRequest struct {
-	Repositories *[]string         `json:"repositories,omitempty"`
+	Repositories []string          `json:"repositories"`
 	Permissions  map[string]string `json:"permissions"`
+}
+
+// TokenRequestAllRepos is a struct that contains the requested permissions/scopes
+// that are requested when generating a new installation access token.
+// This struct intentionally omits the repository properties to generate a token
+// for all repositories granted to this GitHub app installation.
+type TokenRequestAllRepos struct {
+	Permissions map[string]string `json:"permissions"`
 }
 
 // GitHubApp is an object that can be used to generate application level JWTs
@@ -203,15 +211,34 @@ func (g *GitHubApp) generateAppJWT() ([]byte, error) {
 // access token for this application installation with the requested
 // permissions and repositories.
 func (g *GitHubApp) AccessToken(ctx context.Context, request *TokenRequest) (string, error) {
+	requestJSON, err := json.Marshal(request)
+	if err != nil {
+		return "", fmt.Errorf("error marshalling request data: %w", err)
+	}
+
+	return g.githubAccessToken(ctx, requestJSON)
+}
+
+// AccessTokenAllRepos calls the GitHub API to generate a new
+// access token for this application installation with the requested
+// permissions and all granted repositories.
+func (g *GitHubApp) AccessTokenAllRepos(ctx context.Context, request *TokenRequestAllRepos) (string, error) {
+	requestJSON, err := json.Marshal(request)
+	if err != nil {
+		return "", fmt.Errorf("error marshalling request data: %w", err)
+	}
+
+	return g.githubAccessToken(ctx, requestJSON)
+}
+
+// githubAccessToken calls the GitHub API to generate a new
+// access token with provided JSON payload bytes.
+func (g *GitHubApp) githubAccessToken(ctx context.Context, requestJSON []byte) (string, error) {
 	appJWT, err := g.AppToken()
 	if err != nil {
 		return "", fmt.Errorf("error generating app jwt: %w", err)
 	}
 	requestURL := fmt.Sprintf(g.config.accessTokenURLPattern, g.config.InstallationID)
-	requestJSON, err := json.Marshal(request)
-	if err != nil {
-		return "", fmt.Errorf("error marshalling request data: %w", err)
-	}
 
 	requestReader := bytes.NewReader(requestJSON)
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, requestURL, requestReader)

--- a/githubapp/githubapp_test.go
+++ b/githubapp/githubapp_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -133,7 +134,7 @@ func TestConfig_NewConfig(t *testing.T) {
 	}
 }
 
-func TestGitHubApp_AccessToken(t *testing.T) {
+func TestGitHubApp_githubAccessToken(t *testing.T) {
 	t.Parallel()
 
 	rsaPrivateKey, err := rsa.GenerateKey(rand.Reader, 2048)
@@ -220,8 +221,13 @@ func TestGitHubApp_AccessToken(t *testing.T) {
 			}))
 			tc.options = append(tc.options, WithAccessTokenURLPattern(fakeGitHub.URL+"/%s/access_tokens"))
 
+			requestJSON, err := json.Marshal(&TokenRequest{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
 			app := New(NewConfig(tc.appID, tc.installID, rsaPrivateKey, tc.options...))
-			got, err := app.AccessToken(context.Background(), &TokenRequest{})
+			got, err := app.githubAccessToken(context.Background(), requestJSON)
 			if diff := testutil.DiffErrString(err, tc.expErr); diff != "" {
 				t.Errorf(diff)
 			}


### PR DESCRIPTION
Create specific function for calling the GitHub API for generating installation access tokens.

