### PR TITLE
feat: add scancode action and reusable workflow

### DIFF
--- a/.github/actions/scancode/action.yml
+++ b/.github/actions/scancode/action.yml
@@ -1,0 +1,31 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#      http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'Scancode'
+description: 'Scan licenses and copyrights in code'
+inputs:
+  directory-to-scan:
+    description: 'Which directory in the repository to scan.'
+    required: false
+    default: '.'
+outputs:
+  json:
+    description: 'The scancode result json file path'
+  csv:
+    description: 'The scancode result csv file path'
+runs:
+  using: 'docker'
+  image: '../../../scancode/Dockerfile'
+  args:
+    - '${{ inputs.directory-to-scan }}'

--- a/.github/workflows/scancode.yml
+++ b/.github/workflows/scancode.yml
@@ -1,0 +1,54 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# reusable workflow to call scancode action to scan licenses and copyrights and
+# upload the results.
+# TODO: add more usage guide here.
+name: 'scancode'
+on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'Which branch to scan.'
+        required: false
+        type: 'string'
+        default: 'main'
+env:
+  REPO_ROOT: '${{ github.repository }}'
+jobs:
+  scancode:
+    runs-on: 'ubuntu-latest'
+    name: 'Scan code for licenses and copyrights'
+    permissions:
+      contents: 'read'
+    steps:
+      - run: 'mkdir -p ${{ env.REPO_ROOT }}'
+      # Checkout the repo branch to the given path.
+      - uses: 'actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9' # ratchet:actions/checkout@v3
+        with:
+          path: '${{ env.REPO_ROOT }}'
+          ref: '${{ inputs.branch }}'
+      - name: 'Scan the code'
+        id: 'scancode'
+        uses: 'abcxyz/pkg/.github/actions/scancode@main' # ratchet:exclude
+        with:
+          directory-to-scan: '${{ env.REPO_ROOT }}'
+      # Upload the scancode result artifacts to GitHub Action artifact, see
+      # https://docs.github.com/en/actions/managing-workflow-runs/downloading-workflow-artifacts.
+      - uses: 'actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32' # ratchet:actions/upload-artifact@v3
+        with:
+          name: 'scancode output'
+          path: |
+            ${{ steps.scancode.outputs.json }}
+            ${{ steps.scancode.outputs.csv }}

--- a/scancode/Dockerfile
+++ b/scancode/Dockerfile
@@ -1,0 +1,35 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM python:3.10
+
+ENV SCANCODE_RELEASE=32.0.8
+
+RUN apt-get update && apt-get install -y bzip2 xz-utils zlib1g libxml2-dev libxslt1-dev
+
+ADD "https://github.com/nexB/scancode-toolkit/archive/refs/tags/v${SCANCODE_RELEASE}.tar.gz" .
+
+RUN mkdir scancode-toolkit && tar xzvf v${SCANCODE_RELEASE}.tar.gz -C scancode-toolkit --strip-components=1
+
+WORKDIR /scancode-toolkit
+
+RUN ./scancode --help
+
+ENV PATH=$HOME/scancode-toolkit:$PATH
+
+RUN pip3 install pyyaml
+
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/scancode/entrypoint.sh
+++ b/scancode/entrypoint.sh
@@ -1,0 +1,24 @@
+#!/bin/sh -l
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cd /scancode-toolkit
+
+./scancode /github/workspace/$1 \
+  --json /github/workspace/scancode.json \
+  --csv /github/workspace/scancode.csv \
+  --license --package --copyright --license-score=70
+
+echo "json=scancode.json" >> $GITHUB_OUTPUT
+echo "csv=scancode.csv" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Goal: A Github action/workflow to run on workflow_dispatch on the entire repo to get all licenses, dependencies, and copyrights in a json and csv file.