### PR TITLE
Add custom "runs-on" key to reusable workflows

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -52,6 +52,10 @@ name: 'create-tag'
 on:
   workflow_call:
     inputs:
+      runs-on:
+        description: 'The GitHub runner on which to execute. This must be a valid JSON but can represent a string, array of strings, or object.'
+        type: 'string'
+        default: '"ubuntu-latest"'
       tag:
         description: 'The name of the tag to be created.'
         type: 'string'
@@ -110,7 +114,7 @@ env:
 
 jobs:
   print-inputs:
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ fromJSON(inputs.runs-on) }} # yamllint disable-line
     steps:
       - name: 'job summary'
         run: |
@@ -121,7 +125,7 @@ jobs:
           echo "- message: ${MESSAGE}" >> $GITHUB_STEP_SUMMARY
 
   create-tag:
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ fromJSON(inputs.runs-on) }} # yamllint disable-line
     needs: 'print-inputs'
     # Only running the job when the triggering branch is the default branch.
     if: '${{ github.ref_name == github.event.repository.default_branch }}'
@@ -204,7 +208,7 @@ jobs:
             return `Created lightweight tag (${tag}), branch (${branch}), commit (${sha}), message(${message}).`
 
   print-outputs:
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ fromJSON(inputs.runs-on) }} # yamllint disable-line
     needs: 'create-tag'
     steps:
       - name: 'job summary'

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -17,6 +17,10 @@ name: 'go-lint'
 on:
   workflow_call:
     inputs:
+      runs-on:
+        description: 'The GitHub runner on which to execute. This must be a valid JSON but can represent a string, array of strings, or object.'
+        type: 'string'
+        default: '"ubuntu-latest"'
       go_version:
         description: 'The version of Go to install and use.'
         type: 'string'
@@ -42,7 +46,7 @@ jobs:
   # Do not change this job name. Job names are used as identifiers in status
   # checks, and changing this name will cause status checks to fail.
   modules:
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ fromJSON(inputs.runs-on) }} # yamllint disable-line
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9' # ratchet:actions/checkout@v3
@@ -72,7 +76,7 @@ jobs:
   # Do not change this job name. Job names are used as identifiers in status
   # checks, and changing this name will cause status checks to fail.
   golangci:
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ fromJSON(inputs.runs-on) }} # yamllint disable-line
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9' # ratchet:actions/checkout@v3

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -17,10 +17,10 @@ name: 'go-test'
 on:
   workflow_call:
     inputs:
-      os:
-        description: 'Operating system on which to run tests.'
+      runs-on:
+        description: 'The GitHub runner on which to execute. This must be a valid JSON but can represent a string, array of strings, or object.'
         type: 'string'
-        default: 'ubuntu-latest'
+        default: '"ubuntu-latest"'
       go_version:
         description: 'The version of Go to install and use.'
         type: 'string'
@@ -53,7 +53,7 @@ jobs:
   # Do not change this job name. Job names are used as identifiers in status
   # checks, and changing this name will cause status checks to fail.
   test:
-    runs-on: '${{ inputs.os }}'
+    runs-on: ${{ fromJSON(inputs.runs-on) }} # yamllint disable-line
     steps:
       - name: 'Configure environment variables'
         if: '${{ inputs.env != ''{}'' }}'

--- a/.github/workflows/java-lint.yml
+++ b/.github/workflows/java-lint.yml
@@ -17,6 +17,10 @@ name: 'java-lint'
 on:
   workflow_call:
     inputs:
+      runs-on:
+        description: 'The GitHub runner on which to execute. This must be a valid JSON but can represent a string, array of strings, or object.'
+        type: 'string'
+        default: '"ubuntu-latest"'
       java_version:
         description: 'The version of Java to install and use.'
         type: 'string'
@@ -42,7 +46,7 @@ jobs:
   # Do not change this job name. Job names are used as identifiers in status
   # checks, and changing this name will cause status checks to fail.
   format:
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ fromJSON(inputs.runs-on) }} # yamllint disable-line
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9' # ratchet:actions/checkout@v3

--- a/.github/workflows/scancode.yml
+++ b/.github/workflows/scancode.yml
@@ -48,6 +48,10 @@ name: 'scancode'
 on:
   workflow_call:
     inputs:
+      runs-on:
+        description: 'The GitHub runner on which to execute. This must be a valid JSON but can represent a string, array of strings, or object.'
+        type: 'string'
+        default: '"ubuntu-latest"'
       branch:
         description: 'Which branch to scan.'
         required: false
@@ -57,7 +61,7 @@ env:
   REPO_ROOT: '${{ github.repository }}'
 jobs:
   scancode:
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ fromJSON(inputs.runs-on) }} # yamllint disable-line
     name: 'Scan code for licenses and copyrights'
     permissions:
       contents: 'read'

--- a/.github/workflows/terraform-lint.yml
+++ b/.github/workflows/terraform-lint.yml
@@ -17,6 +17,10 @@ name: 'terraform-lint'
 on:
   workflow_call:
     inputs:
+      runs-on:
+        description: 'The GitHub runner on which to execute. This must be a valid JSON but can represent a string, array of strings, or object.'
+        type: 'string'
+        default: '"ubuntu-latest"'
       terraform_version:
         description: 'The version of Terraform to install and use.'
         type: 'string'
@@ -41,7 +45,7 @@ jobs:
   # Do not change this job name. Job names are used as identifiers in status
   # checks, and changing this name will cause status checks to fail.
   lint:
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ fromJSON(inputs.runs-on) }} # yamllint disable-line
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9' # ratchet:actions/checkout@v3

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -17,6 +17,10 @@ name: 'yaml-lint'
 on:
   workflow_call:
     inputs:
+      runs-on:
+        description: 'The GitHub runner on which to execute. This must be a valid JSON but can represent a string, array of strings, or object.'
+        type: 'string'
+        default: '"ubuntu-latest"'
       yamllint_url:
         description: 'The URL to a yamllint config file. This is only used if no file is found in the local directory.'
         type: 'string'
@@ -38,7 +42,7 @@ jobs:
   # Do not change this job name. Job names are used as identifiers in status
   # checks, and changing this name will cause status checks to fail.
   yamllint:
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{ fromJSON(inputs.runs-on) }} # yamllint disable-line
     steps:
       - name: 'Checkout'
         uses: 'actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9' # ratchet:actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -15,6 +15,32 @@ which encapsulate common CI/CD logic to reduce repetition. For security, the
 reusable workflows are pinned to specific references using
 [ratchet](https://github.com/sethvargo/ratchet).
 
+The reusable workflows use a default runner image of `ubuntu-latest`, since this
+works for most use cases. We do not recommend customizing the runner image
+unless you need additional performance. To customize the runner image, set the
+`runs-on` key as an input to the reusable workflow to a **valid JSON string**
+representing the [GitHub `runs-on`
+configuration](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idruns-on).
+Because GitHub Actions reusable workflows do not support complex input types,
+these values must be a valid JSON-encoded string.
+
+```yaml
+# Example of using a different runner
+uses: 'abcxyz/pkg/.github/workflows/workflow.yml@main'
+with:
+  runs-on: '"macos-latest"' # double quoting is required
+
+# Example of using a self-hosted runner
+uses: 'abcxyz/pkg/.github/workflows/workflow.yml@main'
+with:
+  runs-on: '["self-hosted", "ubuntu-22.04"]'
+
+# Example of using a label
+uses: 'abcxyz/pkg/.github/workflows/workflow.yml@main'
+with:
+  runs-on: '{"label": "4-core"}'
+```
+
 
 #### go-lint.yml
 


### PR DESCRIPTION
This provides users more control over the underlying runner image used to when executing a reusable workflow. The defaults are unchanged.

~It's unclear if this will "just work" for object inputs (e.g. `{labels: 'my-runner'}`) for self-hosted runners, or if further JSON incantations will be required.~ It works!

Note: we already had this functionality for the "go-test" reusable workflow, but it was named "os". This PR remove "os" as an input, since it really should have been named "runs-on" in the first place. I searched, and the only existing usage of "os" is [in abcxyz/abc](https://github.com/abcxyz/abc/blob/9e69ab89e7a6af7ee4f389b4a0e1aa75aa4d3f3a/.github/workflows/lint-test.yml#L47), so I will have a PR ready to address the migration once this merges.