### PR TITLE
Allow create tag on branches that are not default branch

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -169,12 +169,6 @@ jobs:
             const annotatedTag = process.env.ANNOTATED_TAG
             const message = process.env.MESSAGE
 
-            // TODO(#215): Once prevent self-review is supported by GitHub, we can remove this condition.
-            if (branch != '${{ github.event.repository.default_branch }}') {
-              core.setFailed(`branch (${branch}) is not the repository default branch (${{ github.event.repository.default_branch }}).`)
-              return
-            }
-
             let sha = '${{ github.sha }}'
             // If the input branch is not the branch of the calling workflow,
             // get the sha of input branch instead.

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -169,6 +169,11 @@ jobs:
             const annotatedTag = process.env.ANNOTATED_TAG
             const message = process.env.MESSAGE
 
+            if (branch != '${{ github.event.repository.default_branch }}') {
+              core.warning(`branch (${branch}) is not the repository default ` +
+              `branch (${{ github.event.repository.default_branch }}).`)
+            }
+
             let sha = '${{ github.sha }}'
             // If the input branch is not the branch of the calling workflow,
             // get the sha of input branch instead.


### PR DESCRIPTION
fix #215 

prevent self-review on deployment has shipped according to https://github.com/github/roadmap/issues/825, it's now on deployment reviewer's hand to check if the tag created on unprotected branches is for valid reasons. 