### PR TITLE
experiment: add gci to golangci-linters to order/group imports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -132,7 +132,6 @@ linters-settings:
       - 'standard'
       - 'default'
       - 'prefix(github.com/abcxyz)'
-      - 'alias'
       - 'blank'
       - 'dot'
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -52,6 +52,7 @@ linters:
     - 'exhaustive'
     - 'exportloopref'
     - 'forcetypeassert'
+    - 'gci'
     - 'gocheckcompilerdirectives'
     - 'godot'
     - 'gofmt'
@@ -125,6 +126,18 @@ linters-settings:
             desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
           - pkg: 'github.com/stretchr/testify'
             desc: 'use the standard library for tests'
+
+  gci:
+    sections:
+      - 'standard'
+      - 'default'
+      - 'prefix(github.com/abcxyz)'
+      - 'alias'
+      - 'blank'
+      - 'dot'
+
+    skip-generated: true
+    custom-order: true
 
   gofumpt:
     # default: false

--- a/bqutil/query.go
+++ b/bqutil/query.go
@@ -21,9 +21,10 @@ import (
 	"fmt"
 
 	"cloud.google.com/go/bigquery"
-	"github.com/abcxyz/pkg/logging"
 	"github.com/sethvargo/go-retry"
 	"google.golang.org/api/iterator"
+
+	"github.com/abcxyz/pkg/logging"
 )
 
 // Query is the interface to execute a query.

--- a/bqutil/query_test.go
+++ b/bqutil/query_test.go
@@ -20,10 +20,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/abcxyz/pkg/logging"
-	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sethvargo/go-retry"
+
+	"github.com/abcxyz/pkg/logging"
+	"github.com/abcxyz/pkg/testutil"
 )
 
 type fakeQuery[T any] struct {

--- a/cfgloader/cfgloader_test.go
+++ b/cfgloader/cfgloader_test.go
@@ -19,9 +19,10 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"github.com/sethvargo/go-envconfig"
+
+	"github.com/abcxyz/pkg/testutil"
 )
 
 type fakeCfg struct {

--- a/cli/command_doc_completions_test.go
+++ b/cli/command_doc_completions_test.go
@@ -19,9 +19,10 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/abcxyz/pkg/cli"
 	"github.com/posener/complete/v2"
 	"github.com/posener/complete/v2/predict"
+
+	"github.com/abcxyz/pkg/cli"
 )
 
 type SingCommand struct {

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -27,12 +27,12 @@ import (
 	"strings"
 	"time"
 
-	"github.com/abcxyz/pkg/logging"
-	"github.com/abcxyz/pkg/timeutil"
-
 	"github.com/kr/text"
 	"github.com/posener/complete/v2"
 	"github.com/posener/complete/v2/predict"
+
+	"github.com/abcxyz/pkg/logging"
+	"github.com/abcxyz/pkg/timeutil"
 )
 
 const maxLineLength = 80

--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -24,9 +24,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
-	"github.com/google/go-cmp/cmp"
 )
 
 func TestNewFlagSet(t *testing.T) {

--- a/gcputil/gcputil.go
+++ b/gcputil/gcputil.go
@@ -20,6 +20,7 @@ import (
 	"os"
 
 	"cloud.google.com/go/compute/metadata"
+
 	"github.com/abcxyz/pkg/logging"
 )
 

--- a/githubapp/githubapp.go
+++ b/githubapp/githubapp.go
@@ -26,10 +26,11 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/abcxyz/pkg/cache"
 	"github.com/lestrrat-go/jwx/v2/jwa"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 	"golang.org/x/oauth2"
+
+	"github.com/abcxyz/pkg/cache"
 )
 
 // URL used to retrieve access tokens. The pattern must contain a single '%s' which represents where in the url

--- a/githubapp/githubapp_test.go
+++ b/githubapp/githubapp_test.go
@@ -25,8 +25,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/abcxyz/pkg/testutil"
 )
 
 func TestConfig_NewConfig(t *testing.T) {

--- a/healthcheck/healthcheck.go
+++ b/healthcheck/healthcheck.go
@@ -22,7 +22,6 @@ import (
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
-
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 )
 

--- a/internal/tools/terraformlinter/terraform_linter.go
+++ b/internal/tools/terraformlinter/terraform_linter.go
@@ -25,9 +25,10 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/abcxyz/pkg/workerpool"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
+
+	"github.com/abcxyz/pkg/workerpool"
 )
 
 // Top level terraform types to validate.

--- a/protoutil/conversion_test.go
+++ b/protoutil/conversion_test.go
@@ -18,10 +18,11 @@ package protoutil
 import (
 	"testing"
 
-	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/abcxyz/pkg/testutil"
 )
 
 func TestToProtoStruct(t *testing.T) {

--- a/renderer/funcs_test.go
+++ b/renderer/funcs_test.go
@@ -19,8 +19,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/abcxyz/pkg/testutil"
 	"github.com/google/go-cmp/cmp"
+
+	"github.com/abcxyz/pkg/testutil"
 )
 
 func TestToStringSlice(t *testing.T) {

--- a/serving/serving.go
+++ b/serving/serving.go
@@ -30,8 +30,9 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/abcxyz/pkg/logging"
 	"google.golang.org/grpc"
+
+	"github.com/abcxyz/pkg/logging"
 )
 
 // Server provides a gracefully-stoppable http server implementation.

--- a/serving/serving_doc_test.go
+++ b/serving/serving_doc_test.go
@@ -22,8 +22,9 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/abcxyz/pkg/serving"
 	"google.golang.org/grpc"
+
+	"github.com/abcxyz/pkg/serving"
 )
 
 func Example_hTTP() {

--- a/serving/serving_test.go
+++ b/serving/serving_test.go
@@ -21,10 +21,10 @@ import (
 	"testing"
 	"time"
 
+	"google.golang.org/grpc"
+
 	"github.com/abcxyz/pkg/logging"
 	"github.com/abcxyz/pkg/testutil"
-
-	"google.golang.org/grpc"
 )
 
 func TestNew(t *testing.T) {


### PR DESCRIPTION
Instructions to bring existing repos to this standard:

1. Install gci: `go install github.com/daixiang0/gci@v0.11.2`
2. Run in the repo root `gci write -s standard -s default -s "prefix(github.com/abcxyz)" -s blank -s dot --custom-order --skip-generated .` 