### PR TITLE
fix: add moved block to token types of terraform linter

### DIFF
--- a/internal/tools/terraformlinter/terraform_linter.go
+++ b/internal/tools/terraformlinter/terraform_linter.go
@@ -39,6 +39,7 @@ const (
 	tokenTypeOutput   = "output"
 	tokenTypeLocals   = "locals"
 	tokenTypeImport   = "import"
+	tokenTypeMoved    = "moved"
 )
 
 // List of valid extensions that can be linted.
@@ -193,14 +194,15 @@ func findViolations(content []byte, path string) ([]*ViolationInstance, error) {
 			continue
 		}
 		contents := string(token.Bytes)
-		// Each Ident token starts a new object, we are only looking for resource, module, output and variable types
+		// Each Ident token starts a new object, we are only looking for resource, module, output, variable and moved types
 		if !inBlock && token.Type == hclsyntax.TokenIdent &&
 			(contents == tokenTypeResource ||
 				contents == tokenTypeModule ||
 				contents == tokenTypeOutput ||
 				contents == tokenTypeVariable ||
 				contents == tokenTypeLocals ||
-				contents == tokenTypeImport) {
+				contents == tokenTypeImport ||
+				contents == tokenTypeMoved) {
 			inBlock = true
 			start = idx
 			depth = 0

--- a/internal/tools/terraformlinter/terraform_linter_test.go
+++ b/internal/tools/terraformlinter/terraform_linter_test.go
@@ -668,6 +668,15 @@ func TestTerraformLinter_FindViolations(t *testing.T) {
 			}
 			`,
 		},
+		{
+			name: "allows_moved_blocks",
+			content: `
+				moved {
+					from = google_bigquery_table_iam_member.editors["serviceAccount:service-123456789@dataflow-service-producer-prod.iam.gserviceaccount.com"]
+					to   = module.project.google_bigquery_table_iam_member.editors["serviceAccount:service-123456789@dataflow-service-producer-prod.iam.gserviceaccount.com"]
+				}
+			`,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
This fixes false violations when using moved blocks to refactor terraform. An example of this is when using the moved block to move an IAM resource, whose keys contain hyphens (e.g GCP service accounts).