### PR TITLE
feat: make go test work for windows

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: 'Configure environment variables'
         if: '${{ inputs.env != ''{}'' }}'
         run: |-
-          jq -r "to_entries | map(\"\(.key)=\(.value|tostring)\") | .[]" <<< '${{ inputs.env }}' >> $GITHUB_ENV
+          echo "${{ inputs.env }}" | jq -r "to_entries | map(\"\(.key)=\(.value|tostring)\") | .[]" >> $GITHUB_ENV
 
       - name: 'Checkout'
         uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # ratchet:actions/checkout@v4


### PR DESCRIPTION
make go test work for windows.
Currently go test doesn't work for windows, see https://github.com/abcxyz/abc/actions/runs/7427886424/job/20214319302?pr=348