### PR TITLE
Add gcpmetadata client

### DIFF
--- a/gcpmetadata/client.go
+++ b/gcpmetadata/client.go
@@ -1,0 +1,231 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpmetadata
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/sethvargo/go-retry"
+)
+
+const (
+	// metadataIP is the documented metadata server IP address.
+	metadataIP = "169.254.169.254"
+
+	// metadataHostEnv is the environment variable specifying the GCE metadata
+	// hostname; borrowed from the google-cloud-go package.
+	metadataHostEnv = "GCE_METADATA_HOST"
+
+	// userAgent is the HTTP user agent to use for HTTP calls.
+	userAgent = "abcxyz:pkg/1.0 (+https://github.com/abcxyz/pkg)"
+)
+
+// Option is a configuration for the client.
+type Option func(c *Client) *Client
+
+// WithHost is an option that injects a custom metadata server host.
+func WithHost(host string) Option {
+	return func(c *Client) *Client {
+		c.host = host
+		return c
+	}
+}
+
+// WithHTTPClient is an option that injects a custom HTTP client.
+func WithHTTPClient(client *http.Client) Option {
+	return func(c *Client) *Client {
+		c.httpClient = client
+		return c
+	}
+}
+
+// Client is an HTTP client for interacting with the Google Cloud metadata
+// server. No results are cached and each invocation will result in HTTP
+// requests.
+type Client struct {
+	host       string
+	httpClient *http.Client
+}
+
+// NewClient creates a new HTTP metadata client for interacting with the Google Cloud
+// metadata server.
+func NewClient(opts ...Option) *Client {
+	c := &Client{}
+
+	for _, opt := range opts {
+		if opt != nil {
+			c = opt(c)
+		}
+	}
+
+	// Default host
+	if c.host == "" {
+		c.host = os.Getenv(metadataHostEnv)
+	}
+	if c.host == "" {
+		c.host = metadataIP
+	}
+	c.host = "http://" + c.host + "/computeMetadata/v1/"
+
+	// Default httpClient
+	if c.httpClient == nil {
+		c.httpClient = &http.Client{
+			Transport: &http.Transport{
+				Dial: (&net.Dialer{
+					Timeout:   2 * time.Second,
+					KeepAlive: 30 * time.Second,
+				}).Dial,
+				IdleConnTimeout: 60 * time.Second,
+			},
+			Timeout: 5 * time.Second,
+		}
+	}
+
+	return c
+}
+
+// ProjectID returns the project ID from the metadata server.
+func (c *Client) ProjectID(ctx context.Context) (string, error) {
+	return c.Get(ctx, "project/project-id")
+}
+
+// ProjectNumber returns the project number from the metadata server.
+func (c *Client) ProjectNumber(ctx context.Context) (string, error) {
+	return c.Get(ctx, "project/numeric-project-id")
+}
+
+// Get fetches the metadata server response at the given path.
+func (c *Client) Get(ctx context.Context, pth string) (string, error) {
+	u := c.host + strings.TrimLeft(pth, "/")
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Metadata-Flavor", "Google")
+	req.Header.Set("User-Agent", userAgent)
+
+	b := retry.NewFibonacci(50 * time.Millisecond)
+	b = retry.WithCappedDuration(5*time.Second, b)
+	b = retry.WithMaxDuration(30*time.Second, b)
+
+	var bodyStr string
+	if err := retry.Do(ctx, b, func(ctx context.Context) error {
+		var err error
+		resp, err := c.httpClient.Do(req)
+
+		statusCode := 0
+		if resp != nil {
+			statusCode = resp.StatusCode
+		}
+
+		if resp != nil && resp.Body != nil {
+			defer resp.Body.Close()
+		}
+
+		// Handle retries
+		if shouldRetry(statusCode, err) {
+			return retry.RetryableError(err)
+		}
+
+		// 404 are immediate errors
+		if statusCode == http.StatusNotFound {
+			return fmt.Errorf("metadata does not exist for %q", pth)
+		}
+
+		// Read the entire response.
+		body, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20)) // 2mb
+		if err != nil {
+			return fmt.Errorf("failed to read response body: %w", err)
+		}
+		bodyStr = string(bytes.TrimSpace(body))
+
+		// Ensure we got a 200 response
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("non-200 response: %s", bodyStr)
+		}
+		return nil
+	}); err != nil {
+		return "", fmt.Errorf("failed to get metadata: %w", err)
+	}
+
+	return bodyStr, nil
+}
+
+// temporaryError is an interface for an error that declares itself as
+// temporary. Some of the standard library errors do this.
+type temporaryError interface {
+	Temporary() bool
+}
+
+// unwrappableError is an error that wraps another error.
+type unwrappableError interface {
+	Unwrap() error
+}
+
+// unwrappableErrors is an error that wraps multiple other errors.
+type unwrappableErrors interface {
+	Unwrap() []error
+}
+
+func shouldRetry(status int, err error) bool {
+	// Do not retry success, that's weird.
+	if status == http.StatusOK {
+		return false
+	}
+
+	// Retry server-side errors.
+	if status >= 500 && status <= 599 {
+		return true
+	}
+
+	// Retry on EOF.
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	// Retry temporary errors.
+	var terr temporaryError
+	if ok := errors.As(err, &terr); ok && terr.Temporary() {
+		return true
+	}
+
+	// If this is a wrapped error, do everything above for the inner error(s).
+	var uerr unwrappableError
+	if ok := errors.As(err, &uerr); ok {
+		return shouldRetry(status, uerr.Unwrap())
+	}
+
+	var uerrs unwrappableErrors
+	if ok := errors.As(err, &uerrs); ok {
+		for _, err := range uerrs.Unwrap() {
+			if shouldRetry(status, err) {
+				return true
+			}
+		}
+	}
+
+	// If we got this far, don't retry.
+	return false
+}

--- a/gcpmetadata/client_test.go
+++ b/gcpmetadata/client_test.go
@@ -1,0 +1,187 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gcpmetadata
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClient_ProjectID(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	testServer := testMetadataServer(t)
+	client := NewClient(WithHost(testServer.Listener.Addr().String()))
+
+	got, err := client.ProjectID(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := got, "my-project-id"; got != want {
+		t.Errorf("expected %q to be %q", got, want)
+	}
+}
+
+func TestClient_ProjectNumber(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+
+	testServer := testMetadataServer(t)
+	client := NewClient(WithHost(testServer.Listener.Addr().String()))
+
+	got, err := client.ProjectNumber(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := got, "12345"; got != want {
+		t.Errorf("expected %q to be %q", got, want)
+	}
+}
+
+func TestShouldRetry(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		status int
+		err    error
+		exp    bool
+	}{
+		{
+			name:   "200_ok",
+			status: 200,
+			exp:    false,
+		},
+		{
+			name:   "200_error",
+			status: 200,
+			err:    fmt.Errorf("oops"),
+			exp:    false,
+		},
+		{
+			name:   "500_error",
+			status: 500,
+			err:    fmt.Errorf("oops"),
+			exp:    true,
+		},
+		{
+			name:   "569_ok",
+			status: 569,
+			exp:    true,
+		},
+		{
+			name:   "eof",
+			status: 400,
+			err:    fmt.Errorf("oops: %w", io.ErrUnexpectedEOF),
+			exp:    true,
+		},
+		{
+			name:   "temporary",
+			status: 400,
+			err:    &testTemporaryError{},
+			exp:    true,
+		},
+		{
+			name:   "unwrappable_error",
+			status: 400,
+			err:    &testUnwrappableError{},
+			exp:    true,
+		},
+		{
+			name:   "unwrappable_errors",
+			status: 400,
+			err:    &testUnwrappableErrorsError{},
+			exp:    true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got, want := tc.exp, shouldRetry(tc.status, tc.err); got != want {
+				t.Errorf("expected retry(%d, %v) %t be %t", tc.status, tc.err, got, want)
+			}
+		})
+	}
+}
+
+func testMetadataServer(tb testing.TB) *httptest.Server {
+	tb.Helper()
+
+	staticResponse := func(s string) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Metadata-Flavor") != "Google" {
+				http.Error(w, "missing header", http.StatusBadRequest)
+				return
+			}
+
+			fmt.Fprint(w, s)
+		})
+	}
+
+	mux := http.NewServeMux()
+	mux.Handle("/computeMetadata/v1/project/project-id", staticResponse("my-project-id"))
+	mux.Handle("/computeMetadata/v1/project/numeric-project-id", staticResponse("12345"))
+
+	srv := httptest.NewServer(mux)
+	return srv
+}
+
+type testTemporaryError struct{}
+
+func (e *testTemporaryError) Error() string {
+	return "testTemporaryError"
+}
+
+func (e *testTemporaryError) Temporary() bool {
+	return true
+}
+
+type testUnwrappableError struct{}
+
+func (e *testUnwrappableError) Error() string {
+	return "testUnwrappableError"
+}
+
+func (e *testUnwrappableError) Unwrap() error {
+	return fmt.Errorf("testUnwrappableError: %w", &testTemporaryError{})
+}
+
+type testUnwrappableErrorsError struct{}
+
+func (e *testUnwrappableErrorsError) Error() string {
+	return "testUnwrappableErrorsError"
+}
+
+func (e *testUnwrappableErrorsError) Unwrap() []error {
+	return []error{
+		nil,
+		fmt.Errorf("nope"),
+		fmt.Errorf("probably not"),
+		fmt.Errorf("testUnwrappableErrorsError: %w", &testTemporaryError{}),
+	}
+}

--- a/gcpmetadata/gcpmetadata.go
+++ b/gcpmetadata/gcpmetadata.go
@@ -1,0 +1,17 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package gcpmetadata provides a metadata client for interacting with the
+// Google Cloud metadata server.
+package gcpmetadata

--- a/gcputil/gcputil.go
+++ b/gcputil/gcputil.go
@@ -19,8 +19,7 @@ import (
 	"context"
 	"os"
 
-	"cloud.google.com/go/compute/metadata"
-
+	"github.com/abcxyz/pkg/gcpmetadata"
 	"github.com/abcxyz/pkg/logging"
 )
 
@@ -42,7 +41,7 @@ func ProjectID(ctx context.Context) string {
 		}
 	}
 
-	v, err := metadata.ProjectID()
+	v, err := gcpmetadata.NewClient().ProjectID(ctx)
 	if err != nil {
 		logging.FromContext(ctx).ErrorContext(ctx, "failed to get project id", "error", err)
 		return ""

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/abcxyz/pkg
 go 1.21
 
 require (
-	cloud.google.com/go/compute/metadata v0.2.3
 	github.com/go-sql-driver/mysql v1.7.1
 	github.com/google/go-cmp v0.5.9
 	github.com/hashicorp/hcl/v2 v2.17.0
@@ -14,6 +13,7 @@ require (
 	github.com/ory/dockertest/v3 v3.10.0
 	github.com/posener/complete/v2 v2.1.0
 	github.com/sethvargo/go-envconfig v0.9.0
+	github.com/sethvargo/go-retry v0.2.4
 	golang.org/x/oauth2 v0.11.0
 	golang.org/x/sync v0.3.0
 	golang.org/x/text v0.14.0
@@ -23,7 +23,6 @@ require (
 )
 
 require (
-	cloud.google.com/go/compute v1.23.0 // indirect
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,3 @@
-cloud.google.com/go/compute v1.23.0 h1:tP41Zoavr8ptEqaW6j+LQOnyBBhO7OkOMAGrgLopTwY=
-cloud.google.com/go/compute v1.23.0/go.mod h1:4tCnrn48xsqlwSAiLf1HXMQk8CONslYbdiEZc9FEIbM=
-cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
-cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 h1:L/gRVlceqvL25UVaW/CKtUDjefjrs0SPonmDGUVOYP0=
 github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
@@ -113,6 +109,8 @@ github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
 github.com/sethvargo/go-envconfig v0.9.0 h1:Q6FQ6hVEeTECULvkJZakq3dZMeBQ3JUpcKMfPQbKMDE=
 github.com/sethvargo/go-envconfig v0.9.0/go.mod h1:Iz1Gy1Sf3T64TQlJSvee81qDhf7YIlt8GMUX6yyNFs0=
+github.com/sethvargo/go-retry v0.2.4 h1:T+jHEQy/zKJf5s95UkguisicE0zuF9y7+/vgz08Ocec=
+github.com/sethvargo/go-retry v0.2.4/go.mod h1:1afjQuvh7s4gflMObvjLPaWgluLLyhA1wmVZ6KLpICw=
 github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ=
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
This drops the dependency on cloud.google.com/go/compute/metadata, which also drops the dependency tree on cloud.google.com/go/compute. It comes at the expense of introducing go-retry. I could inline the retries if that's desirable.