### PR TITLE
Default Go lint and test to use version from go.mod

### DIFF
--- a/.github/actions/terraform-linter/action.yml
+++ b/.github/actions/terraform-linter/action.yml
@@ -29,7 +29,7 @@ runs:
         path: 'abcxyz-pkg'
 
     - id: 'setup-go'
-      uses: 'actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe' # ratchet:actions/setup-go@v4
+      uses: 'actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe' # ratchet:actions/setup-go@v5
       with:
         go-version: '1.21'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,13 +29,9 @@ concurrency:
 jobs:
   go_lint:
     uses: './.github/workflows/go-lint.yml'
-    with:
-      go_version: '1.21'
 
   go_test:
     uses: './.github/workflows/go-test.yml'
-    with:
-      go_version: '1.21'
 
   terraform_lint:
     uses: './.github/workflows/terraform-lint.yml'

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -24,7 +24,10 @@ on:
       go_version:
         description: 'The version of Go to install and use.'
         type: 'string'
-        required: true
+      go_version_file:
+        description: 'Path to the go.mod file to extract a version.'
+        type: 'string'
+        default: 'go.mod'
       golangci_url:
         description: 'The URL to a golangci file. This is only used if no file is found in the local directory.'
         type: 'string'
@@ -52,9 +55,10 @@ jobs:
         uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # ratchet:actions/checkout@v4
 
       - name: 'Setup Go'
-        uses: 'actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe' # ratchet:actions/setup-go@v4
+        uses: 'actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491' # ratchet:actions/setup-go@v5
         with:
           go-version: '${{ inputs.go_version }}'
+          go-version-file: '${{ inputs.go_version_file }}'
 
       - name: 'Check modules'
         shell: 'bash'
@@ -82,9 +86,10 @@ jobs:
         uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # ratchet:actions/checkout@v4
 
       - name: 'Setup Go'
-        uses: 'actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe' # ratchet:actions/setup-go@v4
+        uses: 'actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491' # ratchet:actions/setup-go@v5
         with:
           go-version: '${{ inputs.go_version }}'
+          go-version-file: '${{ inputs.go_version_file }}'
           cache: false
 
       - name: 'Lint (download default configuration)'

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -24,7 +24,10 @@ on:
       go_version:
         description: 'The version of Go to install and use.'
         type: 'string'
-        required: true
+      go_version_file:
+        description: 'Path to the go.mod file to extract a version.'
+        type: 'string'
+        default: 'go.mod'
       go_packages:
         description: 'List of go packages to test.'
         type: 'string'
@@ -66,9 +69,10 @@ jobs:
         uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # ratchet:actions/checkout@v4
 
       - name: 'Setup Go'
-        uses: 'actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe' # ratchet:actions/setup-go@v4
+        uses: 'actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491' # ratchet:actions/setup-go@v5
         with:
           go-version: '${{ inputs.go_version }}'
+          go-version-file: '${{ inputs.go_version_file }}'
 
       - name: 'Test'
         shell: 'bash'

--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@ on:
 jobs:
   lint:
     uses: 'abcxyz/pkg/.github/workflows/go-lint.yml@main'
-    with:
-      go_version: '1.21'
 ```
 
 Linting is done via [golangci-lint](https://golangci-lint.run/). If a
@@ -93,8 +91,6 @@ on:
 jobs:
   lint:
     uses: 'abcxyz/pkg/.github/workflows/go-test.yml@main'
-    with:
-      go_version: '1.21'
 ```
 
 Testing is done via the `go test` command with:

--- a/containertest/README.md
+++ b/containertest/README.md
@@ -99,9 +99,7 @@ jobs:
     name: Go Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v4
-      with:
-        go-version: '1.21' # Optional
+    - uses: actions/setup-go@v5
 ```
 
 ... and *don't* do this:

--- a/mysqltest/README.md
+++ b/mysqltest/README.md
@@ -86,9 +86,7 @@ jobs:
     name: Go Test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v4
-      with:
-        go-version: '1.21' # Optional
+    - uses: actions/setup-go@v5
 ```
 
 ... and *don't* do this:


### PR DESCRIPTION
This reduces the number of places to keep Go versions in sync. This is backwards-compatible as `go_version` takes precedence over `go_version_file`.