### PR TITLE
Add chmod +x (executable) to setup-binary action

### DIFF
--- a/.github/actions/setup-binary/action.yml
+++ b/.github/actions/setup-binary/action.yml
@@ -34,6 +34,9 @@ inputs:
     description: 'Add the install_path to the $PATH variable.'
     default: 'false'
     required: false
+  mark_executable:
+    description: 'Name of binary to mark as executable (chmod +x) in install_path. If this value is empty, no chmod will occur.'
+    required: false
 
 runs:
   using: 'composite'
@@ -132,9 +135,6 @@ runs:
 
         "${GOGETTER_PATH}/go-getter" "${DOWNLOAD_URL}" "${INSTALL_PATH}"
 
-        # Mark binary as executable
-        chmod +x ${INSTALL_PATH}/*
-
     - name: 'Save cache binary'
       if: |
         inputs.cache_key != '' && steps.cache-binary.outputs.cache-hit != 'true'
@@ -153,3 +153,13 @@ runs:
         # Add binary to path
         echo "Adding ${INSTALL_PATH} to PATH"
         echo "${INSTALL_PATH}" >> $GITHUB_PATH
+
+    - name: 'Mark binary as executable'
+      if: |
+        inputs.mark_executable != ''
+      shell: 'bash'
+      env:
+        INSTALL_PATH: '${{ inputs.install_path }}'
+        MARK_EXECUTABLE: '${{ inputs.mark_executable }}'
+      run: |-
+        chmod +x ${INSTALL_PATH}/${MARK_EXECUTABLE}

--- a/.github/actions/setup-binary/action.yml
+++ b/.github/actions/setup-binary/action.yml
@@ -15,7 +15,7 @@
 name: 'Setup Binary'
 
 description: |-
-  Use this action to install and cache a binary for use within a GitHub workflow. This action wraps the functionality of go-getter to provide advanced donwload and checksum capabilities.
+  Use this action to install and cache a binary for use within a GitHub workflow. This action wraps the functionality of go-getter to provide advanced download and checksum capabilities.
 
 inputs:
   download_url:
@@ -131,6 +131,9 @@ runs:
         fi
 
         "${GOGETTER_PATH}/go-getter" "${DOWNLOAD_URL}" "${INSTALL_PATH}"
+
+        # Mark binary as executable
+        chmod +x ${INSTALL_PATH}
 
     - name: 'Save cache binary'
       if: |

--- a/.github/actions/setup-binary/action.yml
+++ b/.github/actions/setup-binary/action.yml
@@ -133,7 +133,7 @@ runs:
         "${GOGETTER_PATH}/go-getter" "${DOWNLOAD_URL}" "${INSTALL_PATH}"
 
         # Mark binary as executable
-        chmod +x ${INSTALL_PATH}
+        chmod +x ${INSTALL_PATH}/*
 
     - name: 'Save cache binary'
       if: |

--- a/.github/actions/setup-binary/action.yml
+++ b/.github/actions/setup-binary/action.yml
@@ -25,7 +25,7 @@ inputs:
     description: 'The path on disk in which to extract the binary, this cannot be equal to the current directory. Set `add_to_path` to true to add this to the $PATH.'
     required: true
   binary_subpath:
-    description: 'Name of binary. Needed to set as executable.'
+    description: 'The subpath to the binary relative to the install path. This should include the binary name (e.g. dist/binary-name). Required to set the binary as executable.'
     required: true
   checksum:
     description: 'The checksum for the downloaded artifact. See https://github.com/hashicorp/go-getter#checksumming'

--- a/.github/actions/setup-binary/action.yml
+++ b/.github/actions/setup-binary/action.yml
@@ -24,6 +24,9 @@ inputs:
   install_path:
     description: 'The path on disk in which to extract the binary, this cannot be equal to the current directory. Set `add_to_path` to true to add this to the $PATH.'
     required: true
+  binary_subpath:
+    description: 'Name of binary. Needed to set as executable.'
+    required: true
   checksum:
     description: 'The checksum for the downloaded artifact. See https://github.com/hashicorp/go-getter#checksumming'
     required: false
@@ -33,13 +36,6 @@ inputs:
   add_to_path:
     description: 'Add the install_path to the $PATH variable.'
     default: 'false'
-    required: false
-  set_executable:
-    description: 'Whether or not to mark binary as executable (chmod +x) in install_path. Requires binary_subpath if set to true.'
-    default: 'false'
-    required: false
-  binary_subpath:
-    description: 'Name of binary to set as executable. Error if not provided when set_executable is true.'
     required: false
 
 runs:
@@ -159,16 +155,9 @@ runs:
         echo "${INSTALL_PATH}" >> $GITHUB_PATH
 
     - name: 'Mark binary as executable'
-      if: |
-        contains(fromJSON('["true", "True", "TRUE", "1", "T", "t"]'), inputs.set_executable)
       shell: 'bash'
       env:
         INSTALL_PATH: '${{ inputs.install_path }}'
         BINARY_SUBPATH: '${{ inputs.binary_subpath }}'
       run: |-
-        if [[ -z "${BINARY_SUBPATH}" ]]; then
-          echo "::error ::binary_subpath is a required input when set_executable is true"
-          exit 1
-        fi
-
         chmod +x ${INSTALL_PATH}/${BINARY_SUBPATH}

--- a/.github/actions/setup-binary/action.yml
+++ b/.github/actions/setup-binary/action.yml
@@ -34,8 +34,12 @@ inputs:
     description: 'Add the install_path to the $PATH variable.'
     default: 'false'
     required: false
-  mark_executable:
-    description: 'Name of binary to mark as executable (chmod +x) in install_path. If this value is empty, no chmod will occur.'
+  set_executable:
+    description: 'Whether or not to mark binary as executable (chmod +x) in install_path. Requires binary_subpath if set to true.'
+    default: 'false'
+    required: false
+  binary_subpath:
+    description: 'Name of binary to set as executable. Error if not provided when set_executable is true.'
     required: false
 
 runs:
@@ -156,10 +160,15 @@ runs:
 
     - name: 'Mark binary as executable'
       if: |
-        inputs.mark_executable != ''
+        contains(fromJSON('["true", "True", "TRUE", "1", "T", "t"]'), inputs.set_executable)
       shell: 'bash'
       env:
         INSTALL_PATH: '${{ inputs.install_path }}'
-        MARK_EXECUTABLE: '${{ inputs.mark_executable }}'
+        BINARY_SUBPATH: '${{ inputs.binary_subpath }}'
       run: |-
-        chmod +x ${INSTALL_PATH}/${MARK_EXECUTABLE}
+        if [[ -z "${BINARY_SUBPATH}" ]]; then
+          echo "::error ::binary_subpath is a required input when set_executable is true"
+          exit 1
+        fi
+
+        chmod +x ${INSTALL_PATH}/${BINARY_SUBPATH}

--- a/.github/workflows/setup-binary-test.yml
+++ b/.github/workflows/setup-binary-test.yml
@@ -55,6 +55,7 @@ jobs:
           download_url: 'https://github.com/abcxyz/abc/releases/download/v0.0.1-alpha4/abc_0.0.1-alpha4_${{ matrix.name }}_amd64.${{ matrix.ext }}'
           checksum: '${{ matrix.checksum }}'
           cache_key: '${{ runner.os }}_${{ runner.arch }}_abc_${{ github.sha }}'
+          binary_subpath: 'abc'
 
       - name: 'Setup binary (restore cache)'
         uses: './.github/actions/setup-binary' # ratchet:exclude
@@ -64,6 +65,7 @@ jobs:
           checksum: '${{ matrix.checksum }}'
           cache_key: '${{ runner.os }}_${{ runner.arch }}_abc_${{ github.sha }}'
           add_to_path: true
+          binary_subpath: 'abc'
 
       - name: 'Test'
         shell: 'bash'


### PR DESCRIPTION
Sometimes the downloaded binary wasn't marked as executable (https://github.com/abcxyz/grc/pull/318/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR225).

This fixes the need to have an additional step to mark it with the proper permission.