### PR TITLE
githubauth: fix response parsing

### DIFF
--- a/testutil/integ_test.go
+++ b/testutil/integ_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 )
 
+//nolint:paralleltest // Can't be paralleled because of t.Setenv
 func TestIsIntegration(t *testing.T) {
 	if IsIntegration(t) {
 		t.Errorf("IsIntegration() got 'true' want 'false'")

--- a/testutil/integ_test.go
+++ b/testutil/integ_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 )
 
-//nolint:paralleltest // Can't be paralleled because of t.Setenv
 func TestIsIntegration(t *testing.T) {
 	if IsIntegration(t) {
 		t.Errorf("IsIntegration() got 'true' want 'false'")


### PR DESCRIPTION
This fixes a bug where the TokenSource would return the correct value, but the direct invocations would fail.

This is affecting the latest Minty release.

Review the first commit for the nicer diff. The second commit is moving things around so this mistake doesn't happen again: [1dc001b](https://github.com/abcxyz/pkg/pull/291/commits/1dc001ba704668bb010c6e356a655360b34d655e).