### PR TITLE
Fix race with using DefaultLogger

### DIFF
--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -583,7 +583,7 @@ func TestLogLevelVar(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			logger := logging.DefaultLogger()
+			logger := logging.New(io.Discard, slog.LevelInfo, logging.FormatText, false)
 
 			set := NewFlagSet()
 			f := set.NewSection("FLAGS")


### PR DESCRIPTION
DefaultLogger is a shared global, so sometimes this test will fail if the other tests happen to run in an incantation that changes the logger at the same time.