### PR TITLE
fix: release

### DIFF
--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -71,7 +71,7 @@ jobs:
         uses: 'abcxyz/pkg/.github/actions/create-pull-request@main' # ratchet:exclude
         with:
           token: '${{ steps.mint-token.outputs.token }}'
-          # draft: '${{ inputs.draft }}' # TODO: not yet supported
+          draft: '${{ inputs.draft }}'
           base_branch: '${{ github.event.repository.default_branch }}'
           head_branch: '${{ env.PR_BRANCH }}'
           title: 'Release: v${{ steps.increment-version.outputs.next_version }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,11 @@
 name: 'release'
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - 'ci'
+    types:
+      - 'completed'
     branches:
       - 'main'
       - 'release/**/*'
@@ -25,9 +29,9 @@ concurrency:
 
 jobs:
   release:
-    runs-on: 'ubuntu-latest'
     if: |-
-      startsWith(github.event.head_commit.message, 'Release: v')
+      startsWith(github.event.workflow_run.head_commit.message, 'Release: v')
+    runs-on: 'ubuntu-latest'
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
The `release` workflow is always executed from the default branch, however, the `github.event.workflow_run.head_commit.message` comes from the branch the workflow targets, e.g. `main` or `release/v1`