### PR TITLE
Disable caching on golangci

### DIFF
--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -120,6 +120,7 @@ jobs:
         with:
           args: |-
             --config "${{ steps.load-default-config.outputs.output-file }}"
+          skip-cache: true
           version: '${{ inputs.golangci_lint_version }}'
           working-directory: '${{ inputs.directory }}'
 
@@ -128,5 +129,6 @@ jobs:
           ${{ hashFiles('.golangci.yml', '.golangci.yaml') != '' }}
         uses: 'golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804' # ratchet:golangci/golangci-lint-action@v4
         with:
+          skip-cache: true
           version: '${{ inputs.golangci_lint_version }}'
           working-directory: '${{ inputs.directory }}'


### PR DESCRIPTION
The lint job takes 30s, and then the cache upload is taking 3 minutes ([example](https://github.com/abcxyz/jvs/actions/runs/8057088187/job/22007480261?pr=398)). I'd like to disable this and see what a cacheless world looks like.