### PR TITLE
Cache GitHub App Installations

### DIFF
--- a/githubauth/app_test.go
+++ b/githubauth/app_test.go
@@ -155,7 +155,9 @@ func TestNew(t *testing.T) {
 
 			opts := []cmp.Option{
 				cmp.AllowUnexported(App{}),
-				cmpopts.IgnoreFields(App{}),
+				cmpopts.IgnoreFields(App{},
+					"installationCache",
+					"installationCacheLock"),
 			}
 			if diff := cmp.Diff(tc.want, got, opts...); diff != "" {
 				t.Errorf("mismatch (-want, +got):\n%s", diff)


### PR DESCRIPTION
This caches GitHub App Installations after their initial creation, so future invocations return the exact same installation struct without making upstream API calls. To minimize lock contention, values written into the map are closures which are resolved on invocation. This allows parallel goroutines to resolve installations while still maintaining lock integrity.