### PR TITLE
Add sparse-checkout of config file from main in load-workflow-variables.yml

### DIFF
--- a/.github/actions/load-workflow-variables/action.yml
+++ b/.github/actions/load-workflow-variables/action.yml
@@ -17,6 +17,10 @@ description: |-
   Use this action to load/override variables into GITHUB_ENV.
 
 inputs:
+  ref:
+    description: 'The branch or ref to checkout the configuration from.'
+    required: false
+    default: ''
   working_directory:
     description: 'The working directory to look for the env file, relative to the GitHub workspace.'
     required: false
@@ -33,6 +37,13 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: 'Get Approved Configuration File'
+      uses: 'actions/checkout@v4' # ratchet:actions/checkout@v4
+      with:
+        ref: '${{ inputs.ref || github.event.repository.default_branch }}'
+        sparse-checkout: |
+          ${{ inputs.filepath }}
+        sparse-checkout-cone-mode: 'false'
     - name: 'Load Workflow Variables'
       shell: 'bash'
       env:

--- a/.github/actions/load-workflow-variables/action.yml
+++ b/.github/actions/load-workflow-variables/action.yml
@@ -17,10 +17,6 @@ description: |-
   Use this action to load/override variables into GITHUB_ENV.
 
 inputs:
-  ref:
-    description: 'The branch or ref to checkout the configuration from.'
-    required: false
-    default: ''
   working_directory:
     description: 'The working directory to look for the env file, relative to the GitHub workspace.'
     required: false
@@ -38,9 +34,9 @@ runs:
   using: 'composite'
   steps:
     - name: 'Get Approved Configuration File'
-      uses: 'actions/checkout@v4' # ratchet:actions/checkout@v4
+      uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # ratchet:actions/checkout@v4
       with:
-        ref: '${{ inputs.ref || github.event.repository.default_branch }}'
+        ref: '${{ github.event.repository.default_branch }}'
         sparse-checkout: |
           ${{ inputs.filepath }}
         sparse-checkout-cone-mode: 'false'

--- a/.github/actions/load-workflow-variables/action.yml
+++ b/.github/actions/load-workflow-variables/action.yml
@@ -36,6 +36,7 @@ runs:
     - name: 'Get Approved Configuration File'
       uses: 'actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332' # ratchet:actions/checkout@v4
       with:
+        clean: 'false'
         ref: '${{ github.event.repository.default_branch }}'
         sparse-checkout: |
           ${{ inputs.filepath }}


### PR DESCRIPTION
This change will load workflow variables from a config file checked out from the default branch. This ensures that we are loading variables from an approved file.