### PR TITLE
Fix docstring for logging method

### DIFF
--- a/logging/interceptor.go
+++ b/logging/interceptor.go
@@ -63,7 +63,7 @@ func GRPCStreamingInterceptor(inLogger *slog.Logger, projectID string) grpc.Stre
 	}
 }
 
-// GRPCUnaryInterceptor returns a client-side gRPC unary interceptor that
+// GRPCUnaryInterceptor returns a server-side gRPC unary interceptor that
 // populates a logger with trace data in the context.
 func GRPCUnaryInterceptor(inLogger *slog.Logger, projectID string) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {


### PR DESCRIPTION
`GRPCUnaryInterceptor` returns a [server-side interceptor](https://pkg.go.dev/google.golang.org/grpc@v1.65.0#UnaryServerInterceptor), not client-side.