### PR TITLE
Fix load-workflow-variables issue where config file cannot be found

### DIFF
--- a/.github/actions/load-workflow-variables/action.yml
+++ b/.github/actions/load-workflow-variables/action.yml
@@ -33,6 +33,9 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    # Removes "./" from the input filepath, if exists. This avoids an issue with
+    # the sparse-checkout option in the Checkout step, where a relative path,
+    # e.g. "./env.yml", will not match with the expected "env.yml" file.
     - name: 'Sanitize Input Filepath'
       id: 'sanitize_filepath'
       shell: 'bash'

--- a/.github/actions/load-workflow-variables/action.yml
+++ b/.github/actions/load-workflow-variables/action.yml
@@ -33,20 +33,30 @@ inputs:
 runs:
   using: 'composite'
   steps:
+    - name: 'Sanitize Input Filepath'
+      id: 'sanitize_filepath'
+      shell: 'bash'
+      env:
+        CONFIG_REL_PATH: '${{ inputs.filepath }}'
+      run: |-
+        relpath=${CONFIG_REL_PATH}
+        filepath=$(echo "$relpath" | sed 's/^\.\///')
+        echo "CONFIG_PATH=$filepath" >> "$GITHUB_OUTPUT"
+
     - name: 'Get Approved Configuration File'
       uses: 'actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11' # ratchet:actions/checkout@v4
       with:
         ref: '${{ github.event.repository.default_branch }}'
         path: 'load-workflow-variables/${{ github.sha }}'
         sparse-checkout: |
-          ${{ inputs.filepath }}
+          ${{ steps.sanitize_filepath.outputs.CONFIG_PATH }}
         sparse-checkout-cone-mode: 'false'
 
     - name: 'Load Workflow Variables'
       shell: 'bash'
       env:
         WORKING_DIRECTORY: '${{ inputs.working_directory }}'
-        FILEPATH: 'load-workflow-variables/${{ github.sha }}/${{ inputs.filepath }}'
+        FILEPATH: 'load-workflow-variables/${{ github.sha }}/${{ steps.sanitize_filepath.outputs.CONFIG_PATH }}'
         FAIL_ON_MISSING: '${{ inputs.fail_on_missing }}'
       run: |-
         FILEPATH=$(realpath "${FILEPATH}")


### PR DESCRIPTION
This change removes the `./` prefix from the input filepath before passing the value onto the following steps. If `./guardian.yml` is provided, then this will be sanitized to `guardian.yml`.

This fixes an issue with `load-workflow-variables` action caused by providing a relative path for `inputs.filepath`, e.g. `./guardian.yml` instead of `guardian.yml`. Passing this value to the `sparse-checkout` option of the Checkout step caused the action to not match with the `guardian.yml` file at the root of the repository, resulting in a file not found error in the `Load Workflow Variables` step.