### PR TITLE
feat: add maybe-build-docker.yml workflow

### DIFF
--- a/.github/workflows/ci-docker-test.dockerfile
+++ b/.github/workflows/ci-docker-test.dockerfile
@@ -1,0 +1,14 @@
+FROM debian:bookworm-slim
+
+ENV DEBIAN_FRONTEND noninteractive
+
+RUN apt-get update -y && \
+    apt-get -y install file wget ca-certificates curl jq coreutils --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Gcloud CLI (https://cloud.google.com/sdk/docs/install)
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+    | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
+    && apt-get update -y && apt-get install google-cloud-cli google-cloud-sdk-package-go-module -y --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*

--- a/.github/workflows/ci-docker-test.dockerfile
+++ b/.github/workflows/ci-docker-test.dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update -y && \
-    apt-get -y install file wget ca-certificates curl jq coreutils --no-install-recommends \
+    apt-get -y install file wget ca-certificates curl jq coreutils gnupg --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Gcloud CLI (https://cloud.google.com/sdk/docs/install)

--- a/.github/workflows/ci-docker-test.yml
+++ b/.github/workflows/ci-docker-test.yml
@@ -28,7 +28,7 @@ jobs:
       - 'maybe-create-ci-image'
     runs-on: 'ubuntu-latest'
     container:
-      image: 'ghcr.io/${{ github.repository }}/ci-docker-test:${{ needs.maybe-create-ci-image.outputs.docker-tag }}'
+      image: 'ghcr.io/${{ github.repository }}/ci-docker-test:${{ needs.maybe-create-ci-image.outputs.docker_tag }}'
       credentials:
         username: '${{ github.actor }}'
         password: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/ci-docker-test.yml
+++ b/.github/workflows/ci-docker-test.yml
@@ -40,4 +40,3 @@ jobs:
         shell: 'bash'
         run: |
           which gcloud
-      

--- a/.github/workflows/ci-docker-test.yml
+++ b/.github/workflows/ci-docker-test.yml
@@ -1,0 +1,43 @@
+name: 'ci-docker-test'
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/ci-docker-test.dockerfile'
+      - '.github/workflows/ci-docker-test.yml'
+      - '.github/workflows/maybe-build-docker.yml'
+
+permissions:
+  contents: 'read'  # For checking out repository code.
+  packages: 'write' # For pushing/pulling from github docker registry.
+
+jobs:
+  # First we check if we need to re-build the docker image.
+  # If the hash of the dockerfile has changed then we rebuild and push to
+  # github packages (and optionally GCP Artifact registry).
+  maybe-create-ci-image:
+    uses: './.github/workflows/maybe-build-docker.yml'
+    with:
+      dockerfile: '.github/workflows/ci.dockerfile'
+      github-image-name: 'ghcr.io/${{ github.repo }}/ci-docker-test'
+
+  # Then we run using the latest docker image and build all artifacts in that
+  # container.
+  ci-on-docker-image:
+    needs:
+      - 'maybe-create-ci-image'
+    runs-on: 'ubuntu-latest'
+    container:
+      image: 'ghcr.io/${{ github.repo }}/ci-docker-test:${{ needs.maybe-create-ci-image.outputs.docker-tag }}'
+      credentials:
+        username: '${{ github.actor }}'
+        password: '${{ secrets.GITHUB_TOKEN }}'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b' # ratchet:actions/checkout@v4
+
+      - name: 'Check installs'
+        shell: 'bash'
+        run: |
+          which gcloud
+      

--- a/.github/workflows/ci-docker-test.yml
+++ b/.github/workflows/ci-docker-test.yml
@@ -19,7 +19,7 @@ jobs:
     uses: './.github/workflows/maybe-build-docker.yml'
     with:
       dockerfile: '.github/workflows/ci.dockerfile'
-      github_image_name: 'ghcr.io/${{ github.repo }}/ci-docker-test'
+      github_image_name: 'ghcr.io/${{ github.repository }}/ci-docker-test'
 
   # Then we run using the latest docker image and build all artifacts in that
   # container.
@@ -28,7 +28,7 @@ jobs:
       - 'maybe-create-ci-image'
     runs-on: 'ubuntu-latest'
     container:
-      image: 'ghcr.io/${{ github.repo }}/ci-docker-test:${{ needs.maybe-create-ci-image.outputs.docker-tag }}'
+      image: 'ghcr.io/${{ github.repository }}/ci-docker-test:${{ needs.maybe-create-ci-image.outputs.docker-tag }}'
       credentials:
         username: '${{ github.actor }}'
         password: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/ci-docker-test.yml
+++ b/.github/workflows/ci-docker-test.yml
@@ -19,7 +19,7 @@ jobs:
     uses: './.github/workflows/maybe-build-docker.yml'
     with:
       dockerfile: '.github/workflows/ci.dockerfile'
-      github-image-name: 'ghcr.io/${{ github.repo }}/ci-docker-test'
+      github_image_name: 'ghcr.io/${{ github.repo }}/ci-docker-test'
 
   # Then we run using the latest docker image and build all artifacts in that
   # container.

--- a/.github/workflows/ci-docker-test.yml
+++ b/.github/workflows/ci-docker-test.yml
@@ -18,7 +18,7 @@ jobs:
   maybe-create-ci-image:
     uses: './.github/workflows/maybe-build-docker.yml'
     with:
-      dockerfile: '.github/workflows/ci.dockerfile'
+      dockerfile: '.github/workflows/ci-docker-test.dockerfile'
       github_image_name: 'ghcr.io/${{ github.repository }}/ci-docker-test'
 
   # Then we run using the latest docker image and build all artifacts in that

--- a/.github/workflows/maybe-build-docker.yml
+++ b/.github/workflows/maybe-build-docker.yml
@@ -13,7 +13,7 @@
 #     uses: ./.github/workflows/maybe-build-docker.yml
 #     with:
 #       dockerfile: '.github/workflows/ci.dockerfile' # path to dockerfile to build
-#       github_image_name: 'ghcr.io/${{ github.repo }}/ci-build'
+#       github_image_name: 'ghcr.io/${{ github.repository }}/ci-build'
 #       extra_tag1: 'latest'
 #
 #   build_embedded:
@@ -22,7 +22,7 @@
 #     runs-on:
 #       labels: ['ubuntu-latest']
 #     container:
-#       image: 'ghcr.io/${{ github.repo }}/ci-build:${{ needs.maybe-create-ci-image.outputs.docker_tag }}'
+#       image: 'ghcr.io/${{ github.repository }}/ci-build:${{ needs.maybe-create-ci-image.outputs.docker_tag }}'
 #       credentials:
 #         username: '${{ github.actor }}'
 #         password: '${{ secrets.GITHUB_TOKEN }}'
@@ -44,7 +44,7 @@ on:
         type: 'string'
         description: |-
           The full path of the image to upload in github package registry without the tag.
-          Example: 'ghcr.io/\$\{\{ github.repo \}\}/ci-build'
+          Example: 'ghcr.io/\$\{\{ github.repository \}\}/ci-build'
       artifact_registry_image_name:
         required: false
         type: 'string'

--- a/.github/workflows/maybe-build-docker.yml
+++ b/.github/workflows/maybe-build-docker.yml
@@ -127,6 +127,26 @@ jobs:
       - name: 'Checkout'
         uses: 'actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b' # ratchet:actions/checkout@v4
 
+      - name: 'Check inputs'
+        shell: 'bash'
+        env:
+          DOCKERFILE: '${{ inputs.dockerfile }}'
+          EXTRA_HASH_FILE1: '${{ inputs.extra_hash_file1 }}'
+          EXTRA_HASH_FILE2: '${{ inputs.extra_hash_file2 }}'
+        run: |
+          if [[ ! -f "$DOCKERFILE" ]]; then
+            "Unable to find dockerfile: $DOCKERFILE."
+            exit 1
+          fi
+          if [[ "$EXTRA_HASH_FILE1" != "" && ! -f "$EXTRA_HASH_FILE1" ]]; then
+            "Unable to find extra file: $EXTRA_HASH_FILE1."
+            exit 1
+          fi
+          if [[ "$EXTRA_HASH_FILE2" != "" && ! -f "$EXTRA_HASH_FILE2" ]]; then
+            "Unable to find extra file: $EXTRA_HASH_FILE2."
+            exit 1
+          fi
+
       # Generate the hash of the provided files and use that to determine if the docker image needs to be rebuilt.
       - name: 'Echo docker hash tag'
         id: 'docker-tag'

--- a/.github/workflows/maybe-build-docker.yml
+++ b/.github/workflows/maybe-build-docker.yml
@@ -1,0 +1,252 @@
+# Reusable workflow for building and pushing docker images.
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+#
+# Only re-builds the image if the hash of the dockerfile has changed. Supports
+# pushing both to Google artifact registry and GitHub packages (automatically
+# tags for each if the `github_image_name` and `artifact_registry_image_name`
+# inputs are provided). Also supports building for multiple platforms via the
+# `platforms` argument.
+# Exmaple of using this Workflow:
+#
+# jobs:
+#   maybe-create-ci-image:
+#     uses: ./.github/workflows/maybe-build-docker.yml
+#     with:
+#       dockerfile: '.github/workflows/ci.dockerfile' # path to dockerfile to build
+#       github_image_name: 'ghcr.io/${{ github.repo }}/ci-build'
+#       extra_tag1: 'latest'
+#
+#   build_embedded:
+#     needs:
+#       - 'maybe-create-ci-image'
+#     runs-on:
+#       labels: ['ubuntu-latest']
+#     container:
+#       image: 'ghcr.io/${{ github.repo }}/ci-build:${{ needs.maybe-create-ci-image.outputs.docker_tag }}'
+#       credentials:
+#         username: '${{ github.actor }}'
+#         password: '${{ secrets.GITHUB_TOKEN }}'
+name: 'maybe-build-docker'
+
+on:
+  workflow_call:
+    inputs:
+      runs_on:
+        description: 'The GitHub runner on which to execute. This must be a valid JSON but can represent a string, array of strings, or object.'
+        type: 'string'
+        default: '"ubuntu-latest"'
+      dockerfile:
+        required: true
+        type: 'string'
+        description: 'The path to the dockerfile to build.'
+      github_image_name:
+        required: true
+        type: 'string'
+        description: |-
+          The full path of the image to upload in github package registry without the tag.
+          Example: 'ghcr.io/${{ github.repo }}/ci-build'
+      artifact_registry_image_name:
+        required: false
+        type: 'string'
+        description: |-
+          The full path of the image to upload in artifact registry without the
+          tag. If set, will push the image to the specified artifact registry.
+          Example: 'us-docker.pkg.dev/my-project/my-gar-registry/ci-build'
+      workload_identity_provider:
+        required: false
+        type: 'string'
+        description: |-
+          Required if pushing to google artifact registry. The full identifier
+          of the Workload Identity Provider, including the project number, pool
+          name, and provider name. Fully documented in
+          https://github.com/google-github-actions/auth
+      wif_service_account:
+        required: false
+        type: 'string'
+        description: |-
+          Required if pushing to google artifact registry. Email address or
+          unique identifier of the Google Cloud service account for
+          which to generate credentials. Fully documented in
+          https://github.com/google-github-actions/auth
+      access_token_lifetime:
+        required: false
+        type: 'string'
+        description: |-
+          The amount of time to authenticate to GCP for. Defaults to 1 hour.
+          Used when pushing images to GAR.
+        default: '3600s' # 1 hour
+      platforms:
+        required: false
+        type: 'string'
+        description: 'String delimited list of platforms. e.g. linux/arm64,linux/amd64'
+      extra_hash_file1:
+        required: false
+        type: 'string'
+        description: |-
+          Additional file to use when determining unique hash of docker image.
+          This allows re-triggering a build if another file changes in addition
+          to the dockerfile. This is helpful if you install go deps in a
+          dockerfile (e.g. go.mod) or other deps managed outside of the dockerfile.
+      extra_hash_file2:
+        required: false
+        type: 'string'
+        description: 'Same as extra_hash_file1'
+      extra_tag1:
+        required: false
+        type: 'string'
+        description: 'Additional tag to tag the docker image with.'
+      extra_tag2:
+        required: false
+        type: 'string'
+        description: 'Additional tag to tag the docker image with.'
+      force:
+        type: 'boolean'
+        default: false
+        description: 'Ignore the cache and rebuild the docker image.'
+    outputs:
+      docker_tag:
+        description: 'The unique docker tag of the created image'
+        value: '${{ jobs.maybe-create-docker-image.outputs.docker_tag }}'
+      branch_tag:
+        description: 'The branch tag of the created image.'
+        value: '${{ jobs.maybe-create-docker-image.outputs.branch_tag }}'
+      image_created:
+        description: 'Whether or not an image was created.'
+        value: '${{ jobs.maybe-create-docker-image.outputs.image_created }}'
+
+jobs:
+  maybe-create-docker-image:
+    runs-on: ${{ fromJSON(inputs.runs_on) }} # yamllint disable-line
+
+    outputs:
+      docker_tag: '${{ steps.docker-tag.outputs.tag }}'
+      branch_tag: '${{ steps.docker-tag.outputs.branch_tag }}'
+      image_created: "${{ steps.cache-dockerfile.outputs.cache-hit != 'true' || inputs.force }}"
+
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b' # ratchet:actions/checkout@v4
+
+      # Generate the hash of the provided files and use that to determine if the docker image needs to be rebuilt.
+      - name: 'Echo docker hash tag'
+        id: 'docker-tag'
+        shell: 'bash'
+        run: |
+          echo "tag=${{ hashFiles(inputs.dockerfile, inputs.extra_hash_file1, inputs.extra_hash_file2) }}" >> "$GITHUB_OUTPUT"
+          echo "branch_tag=$(echo "${GITHUB_HEAD_REF:-${GITHUB_REF}}" | sed 's/refs\/heads\///g' | sed 's/\//-/g')" >> "$GITHUB_OUTPUT"
+
+      - id: 'gcp-auth'
+        if: |- 
+          inputs.artifact_registry_image_name != ''
+        uses: 'google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d' # v1
+        with:
+          token_format: 'access_token'
+          workload_identity_provider: '${{ inputs.workload_identity_provider }}'
+          service_account: '${{ inputs.wif_service_account }}'
+          access_token_lifetime: '${{ inputs.access_token_lifetime }}'
+
+      - name: 'Login GitHub Packages'
+        shell: 'bash'
+        env:
+          GH_IMAGE: '${{ inputs.github_image_name }}'
+        run: |
+          # GitHub packages is required if you intend to run container based workflows directly on GitHub.
+          docker login --username ${{ github.actor }} --password-stdin ghcr.io <<< "${{ github.token }}"
+
+      - name: 'Login Artifact Registry'
+        if: |-
+          inputs.artifact_registry_image_name != ''
+        shell: 'bash'
+        env:
+          GAR_IMAGE: '${{ inputs.artifact_registry_image_name }}'
+        run: |
+          GAR_IMAGE_REGISTRY=$(echo "$GAR_IMAGE" | cut -d '/' -f 1)
+          echo '${{ steps.gcp-auth.outputs.access_token }}' | docker login -u oauth2accesstoken --password-stdin "https://$GAR_IMAGE_REGISTRY"
+
+      - name: 'Check dockerfile exists'
+        id: 'cache-dockerfile'
+        shell: 'bash'
+        env:
+          GH_IMAGE: '${{ inputs.github_image_name }}'
+          GAR_IMAGE: '${{ inputs.artifact_registry_image_name }}'
+        run: |
+          # We rebuild the image:
+          #  1. if the dockerfile has changed and never been previously built on any PR/branch.
+          #  2. if the main branch hasn't built this particular hash before.
+
+          if [[ "$GH_IMAGE" != "" ]]; then
+            DOCKER_CHECK=$(docker manifest inspect "$GH_IMAGE:${{ steps.docker-tag.outputs.tag }}" | jq --raw-output '.config.digest' || true)
+            DOCKER_BRANCH_CHECK=$(docker manifest inspect "$GH_IMAGE:${{ steps.docker-tag.outputs.branch_tag }}" | jq --raw-output '.config.digest' || true)
+          elif [[ "$GAR_IMAGE" != "" ]]; then
+            DOCKER_CHECK=$(docker manifest inspect "$GAR_IMAGE:${{ steps.docker-tag.outputs.tag }}" | jq --raw-output '.config.digest' || true)
+            DOCKER_BRANCH_CHECK=$(docker manifest inspect "$GAR_IMAGE:${{ steps.docker-tag.outputs.branch_tag }}" | jq --raw-output '.config.digest' || true)
+          fi
+
+          foundTag=$(if [[ "$DOCKER_CHECK" != "" ]]; then echo "true"; fi)
+          tagsMatch=$(if [[ "$DOCKER_CHECK" = "$DOCKER_BRANCH_CHECK" ]]; then echo "true"; fi)
+          isRunningInPR=$(if [[ "${{ github.ref }}" != 'refs/heads/main' ]]; then echo "true"; fi)
+
+          if [[ $foundTag == 'true' && ($tagsMatch == 'true' || $isRunningInPR == 'true') ]]; then
+            echo "cache-hit=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "cache-hit=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: 'Setup Docker Buildx'
+        if: |-
+          steps.cache-dockerfile.outputs.cache-hit != 'true' || inputs.force
+        env:
+          PLATFORMS: '${{ inputs.platforms }}'
+        run: |
+          if [[ "$PLATFORMS" != "" ]]; then
+            qemuVer=f654e8c1dda9d99f6ec95db08c5019d8bed9a9f4170c21350ea86692712304ef
+            docker pull -q multiarch/qemu-user-static@sha256:${qemuVer}
+            docker run --rm --privileged multiarch/qemu-user-static@sha256:${qemuVer} --install "$PLATFORMS"
+            docker buildx create --name builder-${GITHUB_SHA} --driver docker-container --use
+          fi
+          docker buildx ls
+
+      - name: 'Build and push the Docker image'
+        if: |-
+          steps.cache-dockerfile.outputs.cache-hit != 'true' || inputs.force
+        env:
+          GH_IMAGE: '${{ inputs.github_image_name }}'
+          GAR_IMAGE: '${{ inputs.artifact_registry_image_name }}'
+          EXTRA_TAG1: '${{ inputs.extra_tag1 }}'
+          EXTRA_TAG2: '${{ inputs.extra_tag2 }}'
+          PLATFORMS: '${{ inputs.platforms }}'
+          DOCKERFILE: '${{ inputs.dockerfile }}'
+        run: |
+          tags=()
+          if [[ "$GH_IMAGE" != "" ]]; then
+            tags+=(--tag "$GH_IMAGE:${{ steps.docker-tag.outputs.tag }}")
+            tags+=(--tag "$GH_IMAGE:${{ steps.docker-tag.outputs.branch_tag }}")
+            if [[ "$EXTRA_TAG1" != "" ]]; then
+              tags+=(--tag "$GH_IMAGE:$EXTRA_TAG1")
+            fi
+            if [[ "$EXTRA_TAG2" != "" ]]; then
+              tags+=(--tag "$GH_IMAGE:$EXTRA_TAG2")
+            fi
+          fi
+          if [[ "$GAR_IMAGE" != "" ]]; then
+            tags+=(--tag "$GAR_IMAGE:${{ steps.docker-tag.outputs.tag }}")
+            tags+=(--tag "$GAR_IMAGE:${{ steps.docker-tag.outputs.branch_tag }}")
+            if [[ "$EXTRA_TAG1" != "" ]]; then
+              tags+=(--tag "$GAR_IMAGE:$EXTRA_TAG1")
+            fi
+            if [[ "$EXTRA_TAG2" != "" ]]; then
+              tags+=(--tag "$GAR_IMAGE:$EXTRA_TAG2")
+            fi
+          fi
+
+          if [[ "$PLATFORMS" != "" ]]; then
+            docker buildx build . --file "$DOCKERFILE" --platform="$PLATFORMS" "${tags[@]}" --push
+          else
+            docker buildx build . --file "$DOCKERFILE" "${tags[@]}" --push
+          fi
+
+      - name: 'Cleanup docker config'
+        if: |-
+          always()
+        run: |
+          rm /home/runner/.docker/config.json

--- a/.github/workflows/maybe-build-docker.yml
+++ b/.github/workflows/maybe-build-docker.yml
@@ -44,7 +44,7 @@ on:
         type: 'string'
         description: |-
           The full path of the image to upload in github package registry without the tag.
-          Example: 'ghcr.io/${{ github.repo }}/ci-build'
+          Example: 'ghcr.io/\$\{\{ github.repo \}\}/ci-build'
       artifact_registry_image_name:
         required: false
         type: 'string'

--- a/.github/workflows/maybe-build-docker.yml
+++ b/.github/workflows/maybe-build-docker.yml
@@ -156,7 +156,7 @@ jobs:
           echo "branch_tag=$(echo "${GITHUB_HEAD_REF:-${GITHUB_REF}}" | sed 's/refs\/heads\///g' | sed 's/\//-/g')" >> "$GITHUB_OUTPUT"
 
       - id: 'gcp-auth'
-        if: |- 
+        if: |-
           inputs.artifact_registry_image_name != ''
         uses: 'google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d' # v1
         with:

--- a/README.md
+++ b/README.md
@@ -231,3 +231,4 @@ This is particularly useful:
    forcing them to re-build the image locally every time there is a change.
 3. You are compiling for other architectures and your build tooling does not
    natively support it.
+4. You would prefer to manage CI dependencies in docker rather than github actions.

--- a/README.md
+++ b/README.md
@@ -177,3 +177,57 @@ approval from all requested reviewers.
 
 An admin will need to create a new ruleset within the repo to add want_lgtm_all to be included
 as a required status check.
+
+### maybe-build-docker.yml
+
+Use this workflow to build and push docker images to several supported docker
+registries. Docker images will only be rebuilt if the hash of the dockerfile
+(or other configurable input files) changes.
+
+```yaml
+name: 'ci_docker_test'
+on:
+  pull_request:
+
+permissions:
+  contents: 'read'  # For checking out repository code.
+  packages: 'write' # For pushing/pulling from github docker registry.
+
+jobs:
+  maybe-create-ci-image:
+    uses: abcxyz/pkg/.github/workflows/maybe-build-docker.yml
+    with:
+      dockerfile: '.github/workflows/ci.dockerfile'
+      github-image-name: 'ghcr.io/${{ github.repo }}/ci-docker-test'
+
+  # Then we run using the latest docker image and build all artifacts in that
+  # container.
+  ci-on-docker-image:
+    needs:
+      - 'maybe-create-ci-image'
+    runs-on: 'ubuntu-latest'
+    container:
+      image: 'ghcr.io/${{ github.repo }}/ci-docker-test:${{ needs.maybe-create-ci-image.outputs.docker-tag }}'
+      credentials:
+        username: '${{ github.actor }}'
+        password: '${{ secrets.GITHUB_TOKEN }}'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b' # ratchet:actions/checkout@v4
+
+      - name: 'Run something...'
+        shell: 'bash'
+        run: |
+          # Do something in the docker container context...
+```
+
+For a full list of all input arguments and configuration see the
+[workflow file](.github/workflows/maybe-build-docker.yml).
+
+This is particularly useful:
+
+1. If you have a complex build environment with many non-standard system dependencies.
+2. If you would like to share your CI env easily with engineers without
+   forcing them to re-build the image locally every time there is a change.
+3. You are compiling for other architectures and your build tooling does not
+   natively support it.


### PR DESCRIPTION
This is a workflow that I have found to be particularly useful for complex CI builds and enables engineers to easily utilize the same images used in the CI environment. Some examples where I have used this workflow:
1) CI builds for cross compilation of embedded software on fpga.
2) CI builds where lengthy installation of dependencies from source is required.