### PR TITLE
Multi in-org approvals for out-of-org PRs

### DIFF
--- a/.github/workflows/multi-approvers.js
+++ b/.github/workflows/multi-approvers.js
@@ -1,0 +1,110 @@
+const APPROVED = 'APPROVED';
+const COMMENTED = 'COMMENTED';
+const MIN_APPROVED_COUNT = 2;
+
+/** Returns true if the login exists in the members list. */
+function containsLogin(members, login) {
+  return !!members.find((member) => member.login === login);
+}
+
+/** Returns the number of approvals from members in the given list. */
+function inOrgApprovedCount(members, submittedReviews, prLogin) {
+  const reviewStateByLogin = {};
+  submittedReviews
+    // Remove the PR user.
+    .filter((r) => r.user.login !== prLogin)
+    // Only consider users in the org.
+    .filter((r) => containsLogin(members, r.user.login))
+    // Sort chronologically ascending. Note that a reviewer can submit multiple reviews.
+    .sort((a, b) => new Date(a.submitted_at) - new Date(b.submitted_at))
+    .forEach((r) => {
+      const reviewerLogin = r.user.login;
+
+      // Set state if it does not exist.
+      if (!Object.hasOwn(reviewStateByLogin, reviewerLogin)) {
+        reviewStateByLogin[reviewerLogin] = r.state;
+        return;
+      }
+
+      // Always update state if not approved.
+      if (reviewStateByLogin[reviewerLogin] !== APPROVED) {
+        reviewStateByLogin[reviewerLogin] = r.state;
+        return;
+      }
+
+      // Do not update approved state for a comment.
+      if (reviewStateByLogin[reviewerLogin] === APPROVED && r.state !== COMMENTED) {
+        reviewStateByLogin[reviewerLogin] = r.state;
+      }
+    })
+
+  return Object.values(reviewStateByLogin).filter((s) => s === APPROVED).length;
+}
+
+/** Checks that approval requirements are satisfied. */
+async function onPullRequest({orgMembersPath, prNumber, repoName, repoOwner, github, core}) {
+  const members = require(orgMembersPath);
+  const prResponse = await github.rest.pulls.get({owner: repoOwner, repo: repoName, pull_number: prNumber});
+  const prLogin = prResponse.data.user.login;
+
+  const isOrgMember = containsLogin(members, prLogin);
+
+  if (isOrgMember) {
+    // Do nothing if the pull request owner is a member of the org.
+    core.info(`Pull request login ${prLogin} is a member of the org, therefore no special approval rules apply.`);
+    return;
+  }
+
+  const submittedReviews = await github.paginate(github.rest.pulls.listReviews, {
+    owner: repoOwner,
+    repo: repoName,
+    pull_number: prNumber,
+  });
+
+  const approvedCount = inOrgApprovedCount(members, submittedReviews, prLogin);
+
+  core.info(`Found ${approvedCount} ${APPROVED} reviews.`);
+
+  if (approvedCount < MIN_APPROVED_COUNT) {
+    core.setFailed(`This pull request has ${approvedCount} of ${MIN_APPROVED_COUNT} required approvals from members of the org.`);
+  }
+}
+
+/**
+ * Re-runs the approval checks on pull request review.
+ *
+ * This is required because GitHub treats checks made by pull_request and
+ * pull_request_review as different status checks.
+ */
+async function onPullRequestReview({workflowRef, repoName, repoOwner, branch, prNumber, github, core}) {
+  // Get the filename of the workflow.
+  const workflowFilename = workflowRef.split('@')[0].split('/').pop();
+
+  // Get all failed runs.
+  const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+    owner: repoOwner,
+    repo: repoName,
+    workflow_id: workflowFilename,
+    branch,
+    event: 'pull_request',
+    status: 'failure',
+    per_page: 100,
+  });
+
+  const failedRuns = runs
+    .filter((r) =>
+      r.pull_requests.map((pr) => pr.number).includes(prNumber)
+    )
+    .sort((v) => v.id);
+
+  // If there are failed runs for this PR, re-run the workflow.
+  if (failedRuns.length > 0) {
+    await github.rest.actions.reRunWorkflow({
+      owner: repoOwner,
+      repo: repoName,
+      run_id: failedRuns[0].id,
+    });
+  }
+}
+
+module.exports = {onPullRequest, onPullRequestReview};

--- a/.github/workflows/multi-approvers.yml
+++ b/.github/workflows/multi-approvers.yml
@@ -7,7 +7,7 @@ on:
       # See the README for more.
       org-members-path:
         required: true
-        type: string
+        type: 'string'
 
 permissions:
   actions: 'write'

--- a/.github/workflows/multi-approvers.yml
+++ b/.github/workflows/multi-approvers.yml
@@ -1,0 +1,66 @@
+name: 'multi-approvers'
+
+on:
+  workflow_call:
+    inputs:
+      # Path to a JSON file containing the members of the org.
+      # See the README for more.
+      org-members-path:
+        required: true
+        type: string
+
+permissions:
+  actions: 'write'
+  contents: 'read'
+  pull-requests: 'read'
+
+jobs:
+  multi-approvers:
+    if: contains(fromJSON('["pull_request", "pull_request_review"]'), github.event_name)
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b' # ratchet:actions/checkout@v4
+
+      - name: 'Check approver requirements'
+        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7
+        with:
+          retries: 3
+          script: |-
+            const orgMembersPath = '${{ inputs.org-members-path }}';
+            // Warning: this should not be quoted, otherwise comparisons will not work in JS.
+            const prNumber = ${{ github.event.pull_request.number }}
+            const repoName = '${{ github.event.repository.name }}'
+            const repoOwner = '${{ github.event.repository.owner.login }}'
+            const {onPullRequest} = require('./.github/workflows/multi-approvers.js');
+            await onPullRequest({
+              orgMembersPath,
+              prNumber,
+              repoName,
+              repoOwner,
+              github,
+              core,
+            });
+
+      - name: 'Re-run approver checks'
+        if: github.event_name == 'pull_request_review'
+        uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7
+        with:
+          retries: 3
+          script: |-
+            const branch = '${{ github.event.pull_request.head.ref }}'
+            // Warning: this should not be quoted, otherwise comparisons will not work in JS.
+            const prNumber = ${{ github.event.pull_request.number }}
+            const repoName = '${{ github.event.repository.name }}'
+            const repoOwner = '${{ github.event.repository.owner.login }}'
+            const workflowRef = '${{ github.workflow_ref }}';
+            const {onPullRequestReview} = require('./.github/workflows/multi-approvers.js');
+            await onPullRequestReview({
+              branch,
+              prNumber,
+              repoName,
+              repoOwner,
+              workflowRef,
+              github,
+              core,
+            });

--- a/.github/workflows/multi-approvers.yml
+++ b/.github/workflows/multi-approvers.yml
@@ -16,7 +16,8 @@ permissions:
 
 jobs:
   multi-approvers:
-    if: contains(fromJSON('["pull_request", "pull_request_review"]'), github.event_name)
+    if: |-
+      contains(fromJSON('["pull_request", "pull_request_review"]'), github.event_name)
     runs-on: 'ubuntu-latest'
     steps:
       - name: 'Checkout'
@@ -43,7 +44,8 @@ jobs:
             });
 
       - name: 'Re-run approver checks'
-        if: github.event_name == 'pull_request_review'
+        if: |-
+          github.event_name == 'pull_request_review'
         uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7
         with:
           retries: 3

--- a/README.md
+++ b/README.md
@@ -178,6 +178,67 @@ approval from all requested reviewers.
 An admin will need to create a new ruleset within the repo to add want_lgtm_all to be included
 as a required status check.
 
+#### multi-approvers.yml
+
+Use this workflow to require two in-org approvers for pull requests sent from an
+out-of-org user. This prevents in-org users from creating "sock puppet" accounts
+and approving their own pull requests with their in-org account.
+
+This workflow requires one input: `org-members-path`. This is a JSON formatted
+file with the following schema:
+
+```json
+[
+  {"login": "github-user-name-1"},
+  {"login": "github-user-name-2"}
+]
+```
+
+This file can be generated using the following command:
+
+```bash
+gh api \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  --paginate \
+  /orgs/{org}/members | \
+jq '[.[] | {login}]'
+```
+
+```yaml
+name: 'multi-approvers'
+
+on:
+  pull_request:
+    types:
+      - 'opened'
+      - 'edited'
+      - 'reopened'
+      - 'synchronize'
+      - 'ready_for_review'
+      - 'review_requested'
+      - 'review_request_removed'
+  pull_request_review:
+    types:
+      - 'submitted'
+      - 'dismissed'
+
+permissions:
+  actions: 'write'
+  contents: 'read'
+  pull-requests: 'read'
+
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
+jobs:
+  multi-approvers:
+    uses: './.github/workflows/multi-approvers.yml'
+    with:
+      org-members-path: './members.json'
+```
+
 ### maybe-build-docker.yml
 
 Use this workflow to build and push docker images to several supported docker


### PR DESCRIPTION
GitHub reusable workflow to enforce code review requirements, namely that each PR should be reviewed by a member of the organization. This workflow prevents the use of "sock puppet" accounts to work around this requirement by ensuring that PRs originating from outside the org (from a potential sock puppet account) must be approved by at least two in-org members.

Note that we require a JSON file with all members because the token automatically provided to workflows does not allow access to orgs. See [Permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token).

This members JSON file is problematic because, by definition, the file is stale as soon as it's generated. There are two cases to consider:

1. The JSON file is missing a current member - Not that concerning. The missing member will not be counted as in in-org approver. At worst this will require more reviews.
1. The JSON file contains a member that was removed - Concerning (but no worse than today). The removed member will be counted as an in-org approver when they should not be counted as such.

The above concern can be alleviated by getting access to the orgs API to get real-time org membership information.