### PR TITLE
cli: support "-" and "@" for pipes and files

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,6 +33,7 @@ linters:
     - 'bidichk'
     - 'bodyclose'
     - 'containedctx'
+    # - 'copyloopvar' TODO: enable after everything is upgraded to Go 1.22
     - 'depguard'
     - 'dupword'
     - 'durationcheck'
@@ -40,9 +41,7 @@ linters:
     - 'errchkjson'
     - 'errname'
     - 'errorlint'
-    - 'execinquery'
     - 'exhaustive'
-    - 'exportloopref'
     - 'forcetypeassert'
     - 'gci'
     - 'gocheckcompilerdirectives'
@@ -170,7 +169,7 @@ linters-settings:
 
   sloglint:
     # default: false
-    context-only: true
+    context: 'all'
     # default: false
     static-msg: false
     # default: '' (snake, kebab, camel, pascal)

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -90,8 +90,8 @@ func New[T any](expireAfter time.Duration) *Cache[T] {
 	// largely defeat the purpose. In this case, 50ms is somewhat arbitrary, but
 	// it ensures the CPU is not entirely bound by the sweep operation.
 	sweep := expireAfter / 4.0
-	if min := 50 * time.Millisecond; sweep < min {
-		sweep = min
+	if minimum := 50 * time.Millisecond; sweep < minimum {
+		sweep = minimum
 	}
 	go c.start(sweep)
 

--- a/cli/command_doc_test.go
+++ b/cli/command_doc_test.go
@@ -74,13 +74,13 @@ func (c *CountCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("expected 1 argument, got %q", args)
 	}
 
-	maxStr := args[0]
-	max, err := strconv.ParseInt(maxStr, 10, 64)
+	maximumStr := args[0]
+	maximum, err := strconv.ParseInt(maximumStr, 10, 64)
 	if err != nil {
 		return fmt.Errorf("failed to parse max: %w", err)
 	}
 
-	for i := int64(0); i <= max; i += c.flagStep {
+	for i := int64(0); i <= maximum; i += c.flagStep {
 		c.Outf("%d", i)
 	}
 

--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -702,5 +704,157 @@ func TestFlagSet_Parse(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestFromFileParser(t *testing.T) {
+	t.Parallel()
+
+	goodFilePathAbs := filepath.Join(t.TempDir(), "good")
+	if err := os.WriteFile(goodFilePathAbs, []byte("good\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	goodFilePathRel, err := filepath.Rel(t.TempDir(), goodFilePathAbs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name       string
+		input      string
+		workingDir WorkingDirFunc
+		want       string
+		wantError  string
+	}{
+		{
+			name: "working_dir_error_empty_input",
+			workingDir: func() (string, error) {
+				return "", fmt.Errorf("should not error")
+			},
+			want: "",
+		},
+		{
+			name:  "working_dir_error_prefix_input",
+			input: "@/foo/bar",
+			workingDir: func() (string, error) {
+				return "", fmt.Errorf("working dir error")
+			},
+			wantError: "working dir error",
+		},
+		{
+			name:  "prefix_escaped",
+			input: "\\@foo",
+			want:  "@foo",
+		},
+		{
+			name:  "normal_input_does_not_call_working_dir",
+			input: "foo",
+			workingDir: func() (string, error) {
+				return "", fmt.Errorf("should not error")
+			},
+			want: "foo",
+		},
+		{
+			name:  "relative_path",
+			input: "@" + goodFilePathRel,
+			workingDir: func() (string, error) {
+				return t.TempDir(), nil
+			},
+			want: "good",
+		},
+		{
+			name:  "absolute_path",
+			input: "@" + goodFilePathAbs,
+			want:  "good",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			identityParser := func(val string) (string, error) { return val, nil }
+
+			workingDir := func() (string, error) { return t.TempDir(), nil }
+			if tc.workingDir != nil {
+				workingDir = tc.workingDir
+			}
+
+			got, err := fromFileParser("flag", identityParser, workingDir)(tc.input)
+			if diff := testutil.DiffErrString(err, tc.wantError); diff != "" {
+				t.Error(diff)
+			}
+
+			if got, want := got, tc.want; got != want {
+				t.Errorf("args: expected %q to be %q", got, want)
+			}
+		})
+	}
+}
+
+func TestFromPromptParser(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		input        string
+		promptResult string
+		promptError  error
+		want         string
+		wantError    string
+	}{
+		{
+			name:        "no_prompt_on_empty_input",
+			input:       "",
+			promptError: fmt.Errorf("impossible"),
+		},
+		{
+			name:        "no_prompt_on_extra_characters",
+			input:       "--foo",
+			promptError: fmt.Errorf("impossible"),
+			want:        "--foo",
+		},
+		{
+			name:  "prompt_escaped",
+			input: "\\-",
+			want:  "-",
+		},
+		{
+			name:        "prompt_error",
+			input:       "-",
+			promptError: fmt.Errorf("something happened"),
+			wantError:   "something happened",
+		},
+		{
+			name:         "prompt_result",
+			input:        "-",
+			promptResult: "hello there\n",
+			want:         "hello there",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			identityParser := func(val string) (string, error) { return val, nil }
+
+			prompt := func(_ context.Context, msg string, args ...any) (string, error) {
+				return tc.promptResult, tc.promptError
+			}
+
+			got, err := fromPromptParser("flag", identityParser, prompt)(tc.input)
+			if diff := testutil.DiffErrString(err, tc.wantError); diff != "" {
+				t.Error(diff)
+			}
+
+			if got, want := got, tc.want; got != want {
+				t.Errorf("args: expected %q to be %q", got, want)
+			}
+		})
 	}
 }

--- a/githubauth/app_installation_test.go
+++ b/githubauth/app_installation_test.go
@@ -140,7 +140,7 @@ func TestAppInstallation_AccessToken(t *testing.T) {
 
 			token, err := installation.AccessToken(ctx, tc.req)
 			if diff := testutil.DiffErrString(err, tc.expErr); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 
 			if got, want := token, tc.expToken; got != want {
@@ -270,7 +270,7 @@ func TestAppInstallation_AccessTokenAllRepos(t *testing.T) {
 
 			token, err := installation.AccessTokenAllRepos(ctx, tc.req)
 			if diff := testutil.DiffErrString(err, tc.expErr); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 
 			if got, want := token, tc.expToken; got != want {

--- a/multicloser/multicloser_test.go
+++ b/multicloser/multicloser_test.go
@@ -93,7 +93,7 @@ func TestClose(t *testing.T) {
 		got := c.Close()
 		want := "0\n1\n2\n3\n4"
 		if diff := testutil.DiffErrString(got, want); diff != "" {
-			t.Errorf(diff)
+			t.Error(diff)
 		}
 	})
 }

--- a/serving/serving.go
+++ b/serving/serving.go
@@ -51,7 +51,7 @@ type Server struct {
 func New(port string) (*Server, error) {
 	// Create the net listener first, so the connection ready when we return. This
 	// guarantees that it can accept requests.
-	addr := fmt.Sprintf(":" + port)
+	addr := ":" + port
 	listener, err := net.Listen("tcp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create listener on %s: %w", addr, err)


### PR DESCRIPTION
This PR adds support for flags to optionally allow the user to specify special syntaxes that tell the CLI to read the contents from a pipe, prompt, or file. This behavior is off by default and must be enabled on a per-flag basis.

- If a flag sets `AllowFromFile` to true, then if the value for the flag starts with an "@" symbol, the argument is interpreted as a filepath and the contents are read from disk. This is theoretically possible today with shellisms (e.g. `-foo=$(cat bar.txt)`), but this provides a shell-agnostic implementation. If the file does not start with "@", then the value is read as a string as normal. As a special case where the user really wanted the value to be the literal "@", "\\@" can be used to escape the input.

- If a flag sets `AllowFromPrompt` to true, then if the value for the flag is exactly the string "-", then the flag expects input from stdin or a tty. If neither are present, then the user is prompted. As a special case where the user really wanted the literal value "-", "\\-" can be used to escape the input.

Again, both of these behaviors are off by default and must be enabled on a per-flag basis. In general, I don't expect many flags will use this configuration, but it's useful to be consistent where necessary.

Finally, it looks like there are some new linting errors, since the linter was failing locally for me, so I fixed those up.