### PR TITLE
Fix multi-approvers.js not found bug

### DIFF
--- a/.github/workflows/multi-approvers.yml
+++ b/.github/workflows/multi-approvers.yml
@@ -25,7 +25,7 @@ on:
         type: 'string'
       multi-approvers-js-url:
         description: 'The URL to multi-approvers.js. This should typically not need to be set.'
-        type: string
+        type: 'string'
         default: 'https://raw.githubusercontent.com/abcxyz/pkg/main/.github/workflows/multi-approvers.js'
 
 

--- a/.github/workflows/multi-approvers.yml
+++ b/.github/workflows/multi-approvers.yml
@@ -34,20 +34,29 @@ jobs:
       contains(fromJSON('["pull_request", "pull_request_review"]'), github.event_name)
     runs-on: 'ubuntu-latest'
     steps:
-      - name: 'Checkout'
+      - name: 'Checkout the calling repo'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+
+      - name: 'Checkout multi-approvers.js'
+        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
+        with:
+          path: 'abcxyz/pkg'
+          repository: 'abcxyz/pkg'
+          sparse-checkout: |
+            .github/workflows/multi-approvers.js
+          sparse-checkout-cone-mode: false
 
       - name: 'Check approver requirements'
         uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7
         with:
           retries: 3
           script: |-
-            const orgMembersPath = '${{ inputs.org-members-path }}';
+            const orgMembersPath = '${{ github.workspace }}/${{ inputs.org-members-path }}';
             // Warning: this should not be quoted, otherwise comparisons will not work in JS.
             const prNumber = ${{ github.event.pull_request.number }}
             const repoName = '${{ github.event.repository.name }}'
             const repoOwner = '${{ github.event.repository.owner.login }}'
-            const {onPullRequest} = require('./.github/workflows/multi-approvers.js');
+            const {onPullRequest} = require('./abcxyz/pkg/.github/workflows/multi-approvers.js');
             await onPullRequest({
               orgMembersPath,
               prNumber,
@@ -70,7 +79,7 @@ jobs:
             const repoName = '${{ github.event.repository.name }}'
             const repoOwner = '${{ github.event.repository.owner.login }}'
             const workflowRef = '${{ github.workflow_ref }}';
-            const {onPullRequestReview} = require('./.github/workflows/multi-approvers.js');
+            const {onPullRequestReview} = require('./abcxyz/pkg/.github/workflows/multi-approvers.js');
             await onPullRequestReview({
               branch,
               prNumber,

--- a/.github/workflows/multi-approvers.yml
+++ b/.github/workflows/multi-approvers.yml
@@ -17,11 +17,17 @@ name: 'multi-approvers'
 on:
   workflow_call:
     inputs:
-      # Path to a JSON file containing the members of the org.
+      # Path to a JSON file containing the members of the org. This should be
+      # the full path from the repo root without a leading `/`.
       # See the README for more.
       org-members-path:
         required: true
         type: 'string'
+      multi-approvers-js-url:
+        description: 'The URL to multi-approvers.js. This should typically not need to be set.'
+        type: string
+        default: 'https://raw.githubusercontent.com/abcxyz/pkg/main/.github/workflows/multi-approvers.js'
+
 
 permissions:
   actions: 'write'
@@ -37,14 +43,23 @@ jobs:
       - name: 'Checkout the calling repo'
         uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
 
-      - name: 'Checkout multi-approvers.js'
-        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
-        with:
-          path: 'abcxyz/pkg'
-          repository: 'abcxyz/pkg'
-          sparse-checkout: |
-            .github/workflows/multi-approvers.js
-          sparse-checkout-cone-mode: false
+      - name: 'Download multi-approvers.js'
+        id: 'download-multi-approvers-js'
+        run: |-
+          MULTI_APPROVERS_JS="${RUNNER_TEMP}/${GITHUB_SHA:0:7}.multi-approvers.js"
+
+          # Download the file, passing in authentication to get a higher rate
+          # limit: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
+          curl "${{ inputs.multi-approvers-js-url }}" \
+            --silent \
+            --fail \
+            --location \
+            --header "Authorization: Token ${{ github.token }}" \
+            --output "${MULTI_APPROVERS_JS}"
+
+          # Save the result to an output.
+          echo "::notice::Downloaded multi-approvers.js to ${MULTI_APPROVERS_JS}"
+          echo "output-file=${MULTI_APPROVERS_JS}" >> "${GITHUB_OUTPUT}"
 
       - name: 'Check approver requirements'
         uses: 'actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea' # ratchet:actions/github-script@v7
@@ -56,7 +71,7 @@ jobs:
             const prNumber = ${{ github.event.pull_request.number }}
             const repoName = '${{ github.event.repository.name }}'
             const repoOwner = '${{ github.event.repository.owner.login }}'
-            const {onPullRequest} = require('./abcxyz/pkg/.github/workflows/multi-approvers.js');
+            const {onPullRequest} = require('${{ steps.download-multi-approvers-js.outputs.output-file }}');
             await onPullRequest({
               orgMembersPath,
               prNumber,
@@ -79,7 +94,7 @@ jobs:
             const repoName = '${{ github.event.repository.name }}'
             const repoOwner = '${{ github.event.repository.owner.login }}'
             const workflowRef = '${{ github.workflow_ref }}';
-            const {onPullRequestReview} = require('./abcxyz/pkg/.github/workflows/multi-approvers.js');
+            const {onPullRequestReview} = require('${{ steps.download-multi-approvers-js.outputs.output-file }}');
             await onPullRequestReview({
               branch,
               prNumber,

--- a/README.md
+++ b/README.md
@@ -236,8 +236,10 @@ jobs:
   multi-approvers:
     uses: 'abcxyz/pkg/.github/workflows/multi-approvers.yml@main'
     with:
-      org-members-path: './members.json'
+      org-members-path: '.github/workflows/members.json'
 ```
+
+Note: the `org-members-path` should be the full path to the JSON file.
 
 ### maybe-build-docker.yml
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,8 @@ jobs:
       org-members-path: '.github/workflows/members.json'
 ```
 
-Note: the `org-members-path` should be the full path to the JSON file.
+Note: the `org-members-path` should be the full path to the JSON file without
+the leading `/`.
 
 ### maybe-build-docker.yml
 


### PR DESCRIPTION
Fixes #363, multi-approvers.js not found.

When a reusable workflow uses `require` (via the [github-script](https://github.com/actions/github-script) action) to load a Javascript file, that file must be downloaded (via `curl`) from the git repo.

This PR also fixes another (as yet unreported) bug where the members JSON file would not be loaded correctly. This was caused by the path to the JSON file being incorrect. The root of this issue was a misunderstanding of how the _calling_ and _called_ repos are working together.

### Test plan

1. I've tested similar code in ian-shafer/playground and ian-shafer/playground-2.
2. After the pull request is merged, test using the workflow from ian-shafer/playground (or any other GitHub repo).