### PR TITLE
Disable overflow checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -87,6 +87,7 @@ issues:
   # default: []
   exclude:
     - '^G102:' # gosec: we have to bind to all ifaces in Cloud Run services
+    - '^G115:' # gosec: there's no way to actually satisfy this linter
 
   # default: []
   exclude-rules:


### PR DESCRIPTION
Even with checks, the analyzer can't tell if a precondition was checked, so you end up disabling the linter anyway.