### PR TITLE
Move comment

### DIFF
--- a/.github/actions/create-pull-request/action.yml
+++ b/.github/actions/create-pull-request/action.yml
@@ -468,8 +468,8 @@ runs:
     # This is significantly less code and more readability for one extra API call
     - name: 'Toggle auto-merge'
       id: 'toggle-automerge'
+      # Skip if draft == true, draft PRs cannot modify auto-merge
       if: |-
-        # Skip if draft == true, draft PRs cannot modify auto-merge
         ${{ fromJSON(steps.compute-changes.outputs.has_changes || 'false') && !fromJSON(inputs.draft || 'false')  }}
       env:
         GH_TOKEN: '${{ inputs.token }}'


### PR DESCRIPTION
Apparently comments are NOT ignored in a condition:

```
2025-01-31T21:57:14.5721570Z ##[debug]....=> false
2025-01-31T21:57:14.5721992Z ##[debug]..=> '# Skip if draft == true, draft PRs cannot modify auto-merge
2025-01-31T21:57:14.5722286Z ##[debug]false'
2025-01-31T21:57:14.5722676Z ##[debug]=> '# Skip if draft == true, draft PRs cannot modify auto-merge
2025-01-31T21:57:14.5723313Z ##[debug]false'
2025-01-31T21:57:14.5724103Z ##[debug]Expanded: (true && '# Skip if draft == true, draft PRs cannot modify auto-merge
2025-01-31T21:57:14.5724445Z ##[debug]false')
2025-01-31T21:57:14.5724904Z ##[debug]Result: '# Skip if draft == true, draft PRs cannot modify auto-merge
2025-01-31T21:57:14.5725211Z ##[debug]false'
```

That shows that the string includes the comment, which evaluates to "true". Sigh.