### PR TITLE
Fix description of filepath input to load-workflow-variables

### DIFF
--- a/.github/actions/load-workflow-variables/action.yml
+++ b/.github/actions/load-workflow-variables/action.yml
@@ -22,7 +22,7 @@ inputs:
     required: false
     default: '.'
   filepath:
-    description: 'The YAML filepath to load the configuration from, relative to the GitHub workspace.'
+    description: 'The YAML filepath to load the configuration from. Must be a relative path on the default branch of the repository.'
     required: false
     default: 'env.yml'
   fail_on_missing:


### PR DESCRIPTION
https://github.com/abcxyz/pkg/pull/337 changed the behavior of the load-workflow-variables action so that it no longer considers the state of the GitHub workspace when loading the configuration file, but rather it always loads the configuration file from the default branch that was checked out by the `Get Approved Configuration File` step. This change updates the description of the filepath input variable to match.

#337 introduced a breakage for one of our customers. In their workflow, which was using load-workflow-variables from pre-337, they essentially performed the `Get Approved Configuration File` step themselves by checking out the head of their own repository into a subdirectory in their GitHub workspace, then they set `filepath` to a file in that subdirectory. Once the customer updated their version of load-workflow-variables to a version that included #337 this broke because the `Load Workflow Variables` step now started looking in the `load-workflow-variables/` subdirectory of the workspace, rather than in the subdirectory they had checked out themselves.

I'm not sure if we can undo #337 or otherwise resolve this breakage within the workflow, but at least we can accurately describe the input for current + future users of the action.