### PR TITLE
fix: update create-tag workflow instructions

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -15,15 +15,11 @@
 # Steps:
 #   - Parallel task 1:
 #
-#     - In the abcxyz/abcxyz-services repo, create a new file in the
-#       github-token-minter/deployments/configs/abcxyz directory.
-#       Copy one of the existing files (say pmap.yaml) and customize it by
-#       replacing eg "pmap" with your own repo name (not including the abcxyz/ prefix).
+#     - In your own repo, create a minty config in `./.github/minty.yaml`.
+#       Configure your repo access follow this link:
+#       https://github.com/abcxyz/github-token-minter?tab=readme-ov-file#configuring-repository-access.
 #     - Send this PR for approval and merge it when approved. You can continue
 #       with the next step while you wait for approval.
-#     - After the PR is merged, watch for a GitHub action in this repo that will
-#       deploy your change to the live token instance. Wait for the deployment
-#       to complete.
 #
 #   - Parallel task 2:
 #


### PR DESCRIPTION
The current instructions seems a bit out of date. Update it to use minty.