### PR TITLE
feat: handle escaped commas in slicevar flags

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -875,7 +875,7 @@ func (f *FlagSection) StringSliceVar(i *StringSliceVar) {
 		for _, indexPair := range indices {
 			if indexPair[4] != -1 {
 				part := s[lastMatch:indexPair[4]]
-				parsed := strings.TrimSpace(escapeComma(part))
+				parsed := strings.TrimSpace(unescapeCommas(part))
 				if parsed != "" {
 					final = append(final, parsed)
 				}
@@ -883,7 +883,7 @@ func (f *FlagSection) StringSliceVar(i *StringSliceVar) {
 			}
 		}
 		remainder := s[lastMatch:]
-		parsedRemainder := strings.TrimSpace(escapeComma(remainder))
+		parsedRemainder := strings.TrimSpace(unescapeCommas(remainder))
 		if parsedRemainder != "" {
 			final = append(final, parsedRemainder)
 		}
@@ -924,7 +924,7 @@ func (f *FlagSection) StringSliceVar(i *StringSliceVar) {
 	})
 }
 
-func escapeComma(v string) string {
+func unescapeCommas(v string) string {
 	return strings.ReplaceAll(v, `\,`, ",")
 }
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -43,8 +43,9 @@ import (
 
 const maxLineLength = 80
 
-// var unescapedCommas = regexp.MustCompile(`(?m)(?<!\\),`)
-var unescapedCommas = regexp.MustCompile(`[^\\](,)`)
+// unescapedCommas finds all unescaped commas.
+// var unescapedCommas = regexp.MustCompile(`[^\\](,)`)
+var unescapedCommas = regexp.MustCompile(`(\\.)|(,)`)
 
 type (
 	// LookupEnvFunc is the signature of a function for looking up environment
@@ -873,15 +874,20 @@ func (f *FlagSection) StringSliceVar(i *StringSliceVar) {
 		indices := unescapedCommas.FindAllStringSubmatchIndex(s, -1)
 		lastMatch := 0
 		for _, indexPair := range indices {
-			part := s[lastMatch : indexPair[0]+1]
-			parsed := strings.TrimSpace(escapeComma(part))
-			if parsed != "" {
-				final = append(final, parsed)
+			if indexPair[4] != -1 {
+				part := s[lastMatch:indexPair[4]]
+				parsed := strings.TrimSpace(escapeComma(part))
+				if parsed != "" {
+					final = append(final, parsed)
+				}
+				lastMatch = indexPair[5]
 			}
-			lastMatch = indexPair[1]
 		}
 		remainder := s[lastMatch:len(s)]
-		final = append(final, strings.TrimSpace(escapeComma(remainder)))
+		parsedRemainder := strings.TrimSpace(escapeComma(remainder))
+		if parsedRemainder != "" {
+			final = append(final, parsedRemainder)
+		}
 		return final, nil
 	}
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -883,7 +883,7 @@ func (f *FlagSection) StringSliceVar(i *StringSliceVar) {
 				lastMatch = indexPair[5]
 			}
 		}
-		remainder := s[lastMatch:len(s)]
+		remainder := s[lastMatch:]
 		parsedRemainder := strings.TrimSpace(escapeComma(remainder))
 		if parsedRemainder != "" {
 			final = append(final, parsedRemainder)

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -44,7 +44,6 @@ import (
 const maxLineLength = 80
 
 // unescapedCommas finds all unescaped commas.
-// var unescapedCommas = regexp.MustCompile(`[^\\](,)`)
 var unescapedCommas = regexp.MustCompile(`(\\.)|(,)`)
 
 type (

--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -316,6 +316,12 @@ func TestFlagSection_StringSliceVar(t *testing.T) {
 			exp:  []string{"one"},
 		},
 		{
+			name: "empty_flag_value",
+			args: []string{"-test", ""},
+			def:  []string{"one"},
+			exp:  []string{""},
+		},
+		{
 			name: "overrides_default_single",
 			args: []string{"-test", "a"},
 			def:  []string{"one"},
@@ -356,6 +362,12 @@ func TestFlagSection_StringSliceVar(t *testing.T) {
 			args: []string{"-test", "a,b", "-test", "c"},
 			def:  []string{"a", "b"},
 			exp:  []string{"a", "b", "c"},
+		},
+		{
+			name: "given_escaped_delimiter",
+			args: []string{"-test", `a\,b`, "-test", "c"},
+			def:  []string{"a", "b"},
+			exp:  []string{`a,b`, "c"},
 		},
 	}
 

--- a/cli/flags_test.go
+++ b/cli/flags_test.go
@@ -319,7 +319,13 @@ func TestFlagSection_StringSliceVar(t *testing.T) {
 			name: "empty_flag_value",
 			args: []string{"-test", ""},
 			def:  []string{"one"},
-			exp:  []string{""},
+			exp:  []string{},
+		},
+		{
+			name: "one_empty_value_and_one_non_empty",
+			args: []string{"-test", ",me"},
+			def:  []string{"one"},
+			exp:  []string{"me"},
 		},
 		{
 			name: "overrides_default_single",


### PR DESCRIPTION
Allows users to pass `,` values in their string slice items by escaping them.

Example
`-my-slice-var="This is a message\, please consider,Another message"`
Yields
`[]string{"This is a message, please consider", "Another message"}`