### PR TITLE
feat: allow logging to arbitrary files and stderr

### DIFF
--- a/logging/logger.go
+++ b/logging/logger.go
@@ -117,11 +117,11 @@ func newFromEnv(envPrefix string, getenv func(string) string) *slog.Logger {
 		}
 	}
 
-	logTargetKey := envPrefix + "LOG_TARGET"
-	logTargetValue := strings.TrimSpace(getenv(logTargetKey))
-	target, err := LookupTarget(logTargetValue)
+	targetEnvVarKey := envPrefix + "LOG_TARGET"
+	targetEnvVarValue := strings.TrimSpace(getenv(targetEnvVarKey))
+	target, err := LookupTarget(targetEnvVarValue)
 	if err != nil {
-		panic(fmt.Sprintf("invalid value for %s: %s", logTargetKey, err))
+		panic(fmt.Sprintf("invalid value for %s: %s", targetEnvVarKey, err))
 	}
 
 	return New(target, level, format, debug)

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -117,7 +117,14 @@ func newFromEnv(envPrefix string, getenv func(string) string) *slog.Logger {
 		}
 	}
 
-	return New(os.Stdout, level, format, debug)
+	logTargetKey := envPrefix + "LOG_TARGET"
+	logTargetValue := strings.TrimSpace(getenv(logTargetKey))
+	target, err := LookupTarget(logTargetValue)
+	if err != nil {
+		panic(fmt.Sprintf("invalid value for %s: %s", logTargetKey, err))
+	}
+
+	return New(target, level, format, debug)
 }
 
 // SetLevel adjusts the level on the provided logger. The handler on the given

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -144,6 +144,12 @@ func TestNewFromEnv(t *testing.T) {
 
 		// target
 		{
+			name: "empty_target",
+			env: map[string]string{
+				"LOG_TARGET": "",
+			},
+		},
+		{
 			name: "custom_target",
 			env: map[string]string{
 				"LOG_TARGET": "STDERR",

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -141,6 +141,21 @@ func TestNewFromEnv(t *testing.T) {
 			},
 			wantPanic: "invalid value for LOG_DEBUG: strconv.ParseBool",
 		},
+
+		// target
+		{
+			name: "custom_target",
+			env: map[string]string{
+				"LOG_TARGET": "STDERR",
+			},
+		},
+		{
+			name: "invalid_target",
+			env: map[string]string{
+				"LOG_TARGET": "ME",
+			},
+			wantPanic: "invalid value for LOG_TARGET: no such target \"ME\"",
+		},
 	}
 
 	for _, tc := range cases {

--- a/logging/targets.go
+++ b/logging/targets.go
@@ -22,13 +22,13 @@ import (
 )
 
 const (
-	targetSTDOUTName = "STDOUT"
-	targetSTDERRName = "STDERR"
+	targetStdoutName = "STDOUT"
+	targetStderrName = "STDERR"
 )
 
 var targetNames = []string{
-	targetSTDOUTName,
-	targetSTDERRName,
+	targetStdoutName,
+	targetStderrName,
 }
 
 // TargetNames returns the list of all log target names.
@@ -43,9 +43,9 @@ func LookupTarget(name string) (*os.File, error) {
 	switch v := strings.ToUpper(strings.TrimSpace(name)); v {
 	case "":
 		return os.Stdout, nil
-	case targetSTDOUTName:
+	case targetStdoutName:
 		return os.Stdout, nil
-	case targetSTDERRName:
+	case targetStderrName:
 		return os.Stderr, nil
 	default:
 		return nil, fmt.Errorf("no such target %q, valid targets are %q", name, targetNames)

--- a/logging/targets.go
+++ b/logging/targets.go
@@ -1,0 +1,53 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logging
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+)
+
+const (
+	targetSTDOUTName = "STDOUT"
+	targetSTDERRName = "STDERR"
+)
+
+var targetNames = []string{
+	targetSTDOUTName,
+	targetSTDERRName,
+}
+
+// TargetNames returns the list of all log target names.
+func TargetNames() []string {
+	return slices.Clone(targetNames)
+}
+
+// LookupTarget attempts to get the target that corresponds to the given
+// name. If no such target exists, it returns an error. If the empty string
+// is given, it returns the STDOUT target.
+func LookupTarget(name string) (*os.File, error) {
+	switch v := strings.ToUpper(strings.TrimSpace(name)); v {
+	case "":
+		return os.Stdout, nil
+	case targetSTDOUTName:
+		return os.Stdout, nil
+	case targetSTDERRName:
+		return os.Stderr, nil
+	default:
+		return nil, fmt.Errorf("no such target %q, valid targets are %q", name, targetNames)
+	}
+}

--- a/logging/targets.go
+++ b/logging/targets.go
@@ -35,9 +35,7 @@ var targetNames = []string{
 // is given, it returns the STDOUT target.
 func LookupTarget(name string) (*os.File, error) {
 	switch v := strings.ToUpper(strings.TrimSpace(name)); v {
-	case "":
-		return os.Stdout, nil
-	case targetStdoutName:
+	case "", targetStdoutName: // "" for backwards-compatibility
 		return os.Stdout, nil
 	case targetStderrName:
 		return os.Stderr, nil

--- a/logging/targets.go
+++ b/logging/targets.go
@@ -1,4 +1,4 @@
-// Copyright 2023 The Authors (see AUTHORS file)
+// Copyright 2025 The Authors (see AUTHORS file)
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package logging
 import (
 	"fmt"
 	"os"
-	"slices"
 	"strings"
 )
 
@@ -29,11 +28,6 @@ const (
 var targetNames = []string{
 	targetStdoutName,
 	targetStderrName,
-}
-
-// TargetNames returns the list of all log target names.
-func TargetNames() []string {
-	return slices.Clone(targetNames)
 }
 
 // LookupTarget attempts to get the target that corresponds to the given


### PR DESCRIPTION
Log messages need to be able to be differentiated from parseable binary output. Optionally allowing users OR cli/binary authors to set a default log target (STDOUT or STDERR) allows for easier downstream parsing.

Use case:
* tagrep: some warning condition is met but does not prevent continuation/printing out tags. The warning message is logged to stdout - which makes the user have to parse logs from the stdout in order to grab the tags.
* guardian: some warning condition is met but does not prevent fetching entrypoints. Now the user has to know how to parse entrypoints from stdout in order to use them.

NOTE: I considered making the default log target stderr - but given that I don't understand all of the usages I'm not sure this makes sense. Instead I will leave it up to each binary author to decide. I will update tagrep to default to stderr log target.