### PR TITLE
feat: global log settings

### DIFF
--- a/logging/logger.go
+++ b/logging/logger.go
@@ -129,8 +129,12 @@ func newFromEnv(envPrefix string, getenv func(string) string) *slog.Logger {
 		}
 	}
 
-	targetEnvVarKey := envPrefix + "LOG_TARGET"
+	targetEnvVarKey := "LOG_TARGET"
 	targetEnvVarValue := strings.TrimSpace(getenv(targetEnvVarKey))
+	if targetEnvVarValue == "" {
+		targetEnvVarKey = envPrefix + "LOG_TARGET"
+		targetEnvVarValue = strings.TrimSpace(getenv(targetEnvVarKey))
+	}
 	target, err := LookupTarget(targetEnvVarValue)
 	if err != nil {
 		panic(fmt.Sprintf("invalid value for %s: %s", targetEnvVarKey, err))

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -94,22 +94,34 @@ func NewFromEnv(envPrefix string) *slog.Logger {
 
 // newFromEnv is a helper that makes it easier to test [NewFromEnv].
 func newFromEnv(envPrefix string, getenv func(string) string) *slog.Logger {
-	levelEnvVarKey := envPrefix + "LOG_LEVEL"
+	levelEnvVarKey := "LOG_LEVEL"
 	levelEnvVarValue := strings.TrimSpace(getenv(levelEnvVarKey))
+	if levelEnvVarValue == "" {
+		levelEnvVarKey = envPrefix + "LOG_LEVEL"
+		levelEnvVarValue = strings.TrimSpace(getenv(levelEnvVarKey))
+	}
 	level, err := LookupLevel(levelEnvVarValue)
 	if err != nil {
 		panic(fmt.Sprintf("invalid value for %s: %s", levelEnvVarKey, err))
 	}
 
-	formatEnvVarKey := envPrefix + "LOG_FORMAT"
+	formatEnvVarKey := "LOG_FORMAT"
 	formatEnvVarValue := strings.TrimSpace(getenv(formatEnvVarKey))
+	if formatEnvVarValue == "" {
+		formatEnvVarKey = envPrefix + "LOG_FORMAT"
+		formatEnvVarValue = strings.TrimSpace(getenv(formatEnvVarKey))
+	}
 	format, err := LookupFormat(formatEnvVarValue)
 	if err != nil {
 		panic(fmt.Sprintf("invalid value for %s: %s", formatEnvVarKey, err))
 	}
 
-	debugEnvVarKey := envPrefix + "LOG_DEBUG"
+	debugEnvVarKey := "LOG_DEBUG"
 	debugEnvVarValue := strings.TrimSpace(getenv(debugEnvVarKey))
+	if debugEnvVarValue == "" {
+		debugEnvVarKey = envPrefix + "LOG_DEBUG"
+		debugEnvVarValue = strings.TrimSpace(getenv(debugEnvVarKey))
+	}
 	debug, err := strconv.ParseBool(debugEnvVarValue)
 	if err != nil {
 		if debugEnvVarValue != "" {

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -162,6 +162,25 @@ func TestNewFromEnv(t *testing.T) {
 			},
 			wantPanic: "invalid value for LOG_TARGET: no such target \"ME\"",
 		},
+
+		// globals override
+		{
+			name:      "global_overrides_local",
+			envPrefix: "CUSTOM_",
+			env: map[string]string{
+				"LOG_LEVEL":        "warn",
+				"CUSTOM_LOG_LEVEL": "debug",
+			},
+			wantLevel: LevelWarning,
+		},
+		{
+			name:      "local_used_if_no_global",
+			envPrefix: "CUSTOM_",
+			env: map[string]string{
+				"CUSTOM_LOG_LEVEL": "debug",
+			},
+			wantLevel: LevelDebug,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
# Proposal

Add global logging env vars that take precedent over local custom ones.

NOTE: I considered doing the opposite but the problem is that we have established a pattern of setting the custom logging env vars in the CLI/binary - which means that we would never check the global settings.

# Background

As we scale the usage of abc packages for cli and logging we need to provide a consistent and reliable way to set logging configuration across CLIs. This will be useful for googlers wanting to debug a service/binary without having to know the custom prefix utilized for every single service/binary. Imagine an SRE that wants to interact with one of the abc backed services/binaries - they just need a simple way to configure outputs.

