### PR TITLE
chore: create lint actions to replace logic from lint workflows

### DIFF
--- a/.github/actions/lint-go-modules/action.yml
+++ b/.github/actions/lint-go-modules/action.yml
@@ -1,0 +1,87 @@
+# Copyright 2025 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'lint-go-modules'
+description: 'Lint go modules against the abcxyz style guide.'
+inputs:
+  go_version:
+    description: 'The version of Go to install and use.'
+    type: 'string'
+  go_version_file:
+    description: 'Path to the go.mod file to extract a version.'
+    type: 'string'
+    default: 'go.mod'
+  golangci_url:
+    description: 'The URL to a golangci file. This is only used if no file is found in the local directory.'
+    type: 'string'
+    default: 'https://raw.githubusercontent.com/abcxyz/pkg/main/.golangci.yml'
+  directory:
+    description: 'Directory in which Go files reside.'
+    type: 'string'
+    default: '.'
+  golangci_lint_version:
+    description: 'Version of golangci linter to use'
+    type: 'string'
+    default: 'v1.64'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Setup Go'
+      uses: 'actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34' # ratchet:actions/setup-go@v5
+      with:
+        go-version: '${{ inputs.go_version }}'
+        go-version-file: '${{ inputs.go_version_file }}'
+        cache: false
+
+    - name: 'Lint (download default configuration)'
+      id: 'load-default-config'
+      if: |-
+        ${{ hashFiles('.golangci.yml', '.golangci.yaml') == '' }}
+      run: |-
+        # Create a unique output file outside of the checkout.
+        GOLANGCI_YML="${RUNNER_TEMP}/${GITHUB_SHA:0:7}.golangci.yml"
+
+        # Download the file, passing in authentication to get a higher rate
+        # limit: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
+        curl "${{ inputs.golangci_url }}" \
+          --silent \
+          --fail \
+          --location \
+          --header "Authorization: Token ${{ github.token }}" \
+          --output "${GOLANGCI_YML}"
+
+        # Save the result to an output.
+        echo "::notice::Wrote configuration file to ${GOLANGCI_YML}"
+        echo "output-file=${GOLANGCI_YML}" >> "${GITHUB_OUTPUT}"
+
+    - name: 'Lint (default configuration)'
+      if: |-
+        ${{ hashFiles('.golangci.yml', '.golangci.yaml') == '' }}
+      uses: 'golangci/golangci-lint-action@0adbc47a5910e47adb692df88187ec8c73c76778' # ratchet:golangci/golangci-lint-action@v6
+      with:
+        args: |-
+          --config "${{ steps.load-default-config.outputs.output-file }}"
+        skip-cache: true
+        version: '${{ inputs.golangci_lint_version }}'
+        working-directory: '${{ inputs.directory }}'
+
+    - name: 'Lint (custom configuration)'
+      if: |-
+        ${{ hashFiles('.golangci.yml', '.golangci.yaml') != '' }}
+      uses: 'golangci/golangci-lint-action@0adbc47a5910e47adb692df88187ec8c73c76778' # ratchet:golangci/golangci-lint-action@v6
+      with:
+        skip-cache: true
+        version: '${{ inputs.golangci_lint_version }}'
+        working-directory: '${{ inputs.directory }}'

--- a/.github/actions/lint-go-modules/action.yml
+++ b/.github/actions/lint-go-modules/action.yml
@@ -43,45 +43,16 @@ runs:
       with:
         go-version: '${{ inputs.go_version }}'
         go-version-file: '${{ inputs.go_version_file }}'
-        cache: false
 
-    - name: 'Lint (download default configuration)'
-      id: 'load-default-config'
-      if: |-
-        ${{ hashFiles('.golangci.yml', '.golangci.yaml') == '' }}
+    - name: 'Check modules'
+      shell: 'bash'
+      working-directory: '${{ inputs.directory }}'
       run: |-
-        # Create a unique output file outside of the checkout.
-        GOLANGCI_YML="${RUNNER_TEMP}/${GITHUB_SHA:0:7}.golangci.yml"
-
-        # Download the file, passing in authentication to get a higher rate
-        # limit: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
-        curl "${{ inputs.golangci_url }}" \
-          --silent \
-          --fail \
-          --location \
-          --header "Authorization: Token ${{ github.token }}" \
-          --output "${GOLANGCI_YML}"
-
-        # Save the result to an output.
-        echo "::notice::Wrote configuration file to ${GOLANGCI_YML}"
-        echo "output-file=${GOLANGCI_YML}" >> "${GITHUB_OUTPUT}"
-
-    - name: 'Lint (default configuration)'
-      if: |-
-        ${{ hashFiles('.golangci.yml', '.golangci.yaml') == '' }}
-      uses: 'golangci/golangci-lint-action@0adbc47a5910e47adb692df88187ec8c73c76778' # ratchet:golangci/golangci-lint-action@v6
-      with:
-        args: |-
-          --config "${{ steps.load-default-config.outputs.output-file }}"
-        skip-cache: true
-        version: '${{ inputs.golangci_lint_version }}'
-        working-directory: '${{ inputs.directory }}'
-
-    - name: 'Lint (custom configuration)'
-      if: |-
-        ${{ hashFiles('.golangci.yml', '.golangci.yaml') != '' }}
-      uses: 'golangci/golangci-lint-action@0adbc47a5910e47adb692df88187ec8c73c76778' # ratchet:golangci/golangci-lint-action@v6
-      with:
-        skip-cache: true
-        version: '${{ inputs.golangci_lint_version }}'
-        working-directory: '${{ inputs.directory }}'
+        for d in $(find . -name go.mod); do
+          (cd $(dirname $d) && go mod tidy)
+        done
+        if [ -n "$(git status -s -uall)" ]; then
+          echo "::error title=Go module changes::Detected go module changes"
+          git -c color.ui=always diff
+          exit 1
+        fi

--- a/.github/actions/lint-go/action.yml
+++ b/.github/actions/lint-go/action.yml
@@ -43,16 +43,45 @@ runs:
       with:
         go-version: '${{ inputs.go_version }}'
         go-version-file: '${{ inputs.go_version_file }}'
+        cache: false
 
-    - name: 'Check modules'
-      shell: 'bash'
-      working-directory: '${{ inputs.directory }}'
+    - name: 'Lint (download default configuration)'
+      id: 'load-default-config'
+      if: |-
+        ${{ hashFiles('.golangci.yml', '.golangci.yaml') == '' }}
       run: |-
-        for d in $(find . -name go.mod); do
-          (cd $(dirname $d) && go mod tidy)
-        done
-        if [ -n "$(git status -s -uall)" ]; then
-          echo "::error title=Go module changes::Detected go module changes"
-          git -c color.ui=always diff
-          exit 1
-        fi
+        # Create a unique output file outside of the checkout.
+        GOLANGCI_YML="${RUNNER_TEMP}/${GITHUB_SHA:0:7}.golangci.yml"
+
+        # Download the file, passing in authentication to get a higher rate
+        # limit: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
+        curl "${{ inputs.golangci_url }}" \
+          --silent \
+          --fail \
+          --location \
+          --header "Authorization: Token ${{ github.token }}" \
+          --output "${GOLANGCI_YML}"
+
+        # Save the result to an output.
+        echo "::notice::Wrote configuration file to ${GOLANGCI_YML}"
+        echo "output-file=${GOLANGCI_YML}" >> "${GITHUB_OUTPUT}"
+
+    - name: 'Lint (default configuration)'
+      if: |-
+        ${{ hashFiles('.golangci.yml', '.golangci.yaml') == '' }}
+      uses: 'golangci/golangci-lint-action@0adbc47a5910e47adb692df88187ec8c73c76778' # ratchet:golangci/golangci-lint-action@v6
+      with:
+        args: |-
+          --config "${{ steps.load-default-config.outputs.output-file }}"
+        skip-cache: true
+        version: '${{ inputs.golangci_lint_version }}'
+        working-directory: '${{ inputs.directory }}'
+
+    - name: 'Lint (custom configuration)'
+      if: |-
+        ${{ hashFiles('.golangci.yml', '.golangci.yaml') != '' }}
+      uses: 'golangci/golangci-lint-action@0adbc47a5910e47adb692df88187ec8c73c76778' # ratchet:golangci/golangci-lint-action@v6
+      with:
+        skip-cache: true
+        version: '${{ inputs.golangci_lint_version }}'
+        working-directory: '${{ inputs.directory }}'

--- a/.github/actions/lint-go/action.yml
+++ b/.github/actions/lint-go/action.yml
@@ -1,0 +1,58 @@
+# Copyright 2025 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'lint-go'
+description: 'Lint go against the abcxyz style guide.'
+inputs:
+  go_version:
+    description: 'The version of Go to install and use.'
+    type: 'string'
+  go_version_file:
+    description: 'Path to the go.mod file to extract a version.'
+    type: 'string'
+    default: 'go.mod'
+  golangci_url:
+    description: 'The URL to a golangci file. This is only used if no file is found in the local directory.'
+    type: 'string'
+    default: 'https://raw.githubusercontent.com/abcxyz/pkg/main/.golangci.yml'
+  directory:
+    description: 'Directory in which Go files reside.'
+    type: 'string'
+    default: '.'
+  golangci_lint_version:
+    description: 'Version of golangci linter to use'
+    type: 'string'
+    default: 'v1.64'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Setup Go'
+      uses: 'actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34' # ratchet:actions/setup-go@v5
+      with:
+        go-version: '${{ inputs.go_version }}'
+        go-version-file: '${{ inputs.go_version_file }}'
+
+    - name: 'Check modules'
+      shell: 'bash'
+      working-directory: '${{ inputs.directory }}'
+      run: |-
+        for d in $(find . -name go.mod); do
+          (cd $(dirname $d) && go mod tidy)
+        done
+        if [ -n "$(git status -s -uall)" ]; then
+          echo "::error title=Go module changes::Detected go module changes"
+          git -c color.ui=always diff
+          exit 1
+        fi

--- a/.github/actions/lint-java/action.yml
+++ b/.github/actions/lint-java/action.yml
@@ -1,0 +1,69 @@
+# Copyright 2025 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'lint-java'
+description: 'Lint java against the abcxyz style guide.'
+inputs:
+  java_version:
+    description: 'The version of Java to install and use.'
+    type: 'string'
+    required: true
+  java_distribution:
+    description: 'The distibution of Java to use.'
+    type: 'string'
+    default: 'zulu'
+  google_java_format_version:
+    description: 'The version of google-java-format to use. This must be the full version with no leading "v" prefix.'
+    type: 'string'
+    default: '1.25.2'
+  directory:
+    description: 'Directory in which Java files reside.'
+    type: 'string'
+    default: '.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Setup Java'
+      uses: 'actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12' # ratchet:actions/setup-java@v4
+      with:
+        distribution: '${{ inputs.java_distribution }}'
+        java-version: '${{ inputs.java_version }}'
+
+    - name: 'Download google-java-format'
+      shell: 'bash'
+      run: |-
+        BIN='${{ runner.tool_cache }}/google-java-format-${{ inputs.google_java_format_version }}'
+
+        if [[ -x "${BIN}" ]]; then
+          echo "Already installed!"
+        else
+          curl -sLfo "${BIN}" \
+            "https://github.com/google/google-java-format/releases/download/v${{ inputs.google_java_format_version }}/google-java-format-${{ inputs.google_java_format_version }}-all-deps.jar"
+          chmod +x "${BIN}"
+        fi
+
+    - name: 'Check formatting'
+      shell: 'bash'
+      working-directory: '${{ inputs.directory }}'
+      run: |-
+        shopt -s globstar
+
+        java -jar ${{ runner.tool_cache }}/google-java-format-${{ inputs.google_java_format_version }} -i **/*.java
+
+        if [ -n "$(git status -s -uall)" ]; then
+          echo "::error title=Java formatting::Detected unformatted Java"
+          git -c color.ui=always diff
+          exit 1
+        fi

--- a/.github/actions/lint-shell/action.yml
+++ b/.github/actions/lint-shell/action.yml
@@ -1,0 +1,37 @@
+# Copyright 2025 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'lint-shell'
+description: 'Lint shell against the abcxyz style guide.'
+inputs:
+  target:
+    description: 'File or directory containing shell files to lint.'
+    type: 'string'
+    default: '.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Lint Shell'
+      env:
+        TARGET: '${{ inputs.target }}'
+      run: |-
+        find "${TARGET}" \( -type f -name '*.sh' -or -name '*.bash' -or -name '*.zsh' \) -exec \
+          shellcheck \
+            --check-sourced \
+            --enable=all \
+            --severity=style \
+            --format=tty \
+            --color=always \
+            {} +

--- a/.github/actions/lint-terraform/action.yml
+++ b/.github/actions/lint-terraform/action.yml
@@ -1,0 +1,95 @@
+# Copyright 2025 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'lint-terraform'
+description: 'Lint terraform against the abcxyz style guide.'
+inputs:
+  terraform_version:
+    description: 'The version of Terraform to install and use.'
+    type: 'string'
+    required: true
+  directory:
+    description: 'The directory upon which to lint Terraform configurations.'
+    type: 'string'
+    required: true
+  walk_dirs:
+    description: 'Recursively iteratate the working directory to initialize and validate all child modules.'
+    type: 'boolean'
+    required: false
+    default: true
+  ignored_walk_dirs:
+    description: 'The newline delimited list of directories to ignore when recursively iterating child modules. This input accepts bash globbing.'
+    type: 'string'
+    required: false
+    default: ''
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Setup Terraform'
+      uses: 'hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd' # ratchet:hashicorp/setup-terraform@v3.1.2
+      with:
+        terraform_version: '${{ inputs.terraform_version }}'
+
+    - name: 'Check formatting'
+      shell: 'bash'
+      working-directory: '${{ inputs.directory }}'
+      run: |-
+        terraform fmt -recursive -check -diff
+
+    - name: 'Initialize and validate sub directories'
+      if: '${{ inputs.walk_dirs }}'
+      shell: 'bash'
+      working-directory: '${{ inputs.directory }}'
+      env:
+        IGNORE_DIRS: '${{ inputs.ignored_walk_dirs }}'
+      run: |-
+        TERRAFORM_DIRS="$(find . -name '*.tf' -printf "%h\n" | sort -u | tr '\n' ' ')"
+
+        for DIR in ${TERRAFORM_DIRS}; do
+          IGNORE=false
+          for IGNORE_DIR in ${IGNORE_DIRS}; do
+            if [[ "${DIR}" == $IGNORE_DIR ]]; then
+              IGNORE=true
+              break
+            fi
+          done
+
+          if [[ "${IGNORE}" == "true" ]]; then
+            echo "IGNORE: ${DIR}"
+            continue
+          fi
+
+          echo "::group::${DIR}"
+
+          pushd "${DIR}" &>/dev/null
+          terraform init -backend=false -input=false
+          terraform validate
+          popd &>/dev/null
+
+          echo "::endgroup::"
+        done
+
+    - name: 'Initialize and validate'
+      if: '${{ !inputs.walk_dirs }}'
+      shell: 'bash'
+      working-directory: '${{ inputs.directory }}'
+      run: |-
+        terraform init -backend=false -input=false
+        terraform validate
+
+    - name: 'abcxyz Terraform linter'
+      uses: 'abcxyz/terraform-linter@main' # ratchet:exclude
+      with:
+        paths: '${{ inputs.directory }}'

--- a/.github/actions/lint-yaml/action.yml
+++ b/.github/actions/lint-yaml/action.yml
@@ -1,0 +1,72 @@
+# Copyright 2025 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: 'lint-yaml'
+description: 'Lint yaml against the abcxyz style guide.'
+inputs:
+  yamllint_url:
+    description: 'The URL to a yamllint config file. This is only used if no file is found in the local directory.'
+    type: 'string'
+    default: 'https://raw.githubusercontent.com/abcxyz/pkg/main/.yamllint.yml'
+  yamllint_version:
+    description: 'Version of yamllint linter to use'
+    type: 'string'
+    default: '1.35.1'
+  target:
+    description: 'File or directory containing YAML files to lint.'
+    type: 'string'
+    default: '.'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: 'Setup Python'
+      uses: 'actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38' # ratchet:actions/setup-python@v5
+
+    - name: 'Install yamllint'
+      run: |-
+        pip install --user yamllint==${{ inputs.yamllint_version }}
+
+    - name: 'Lint (download default configuration)'
+      id: 'load-default-config'
+      if: |-
+        ${{ hashFiles('.yamllint.yml', '.yamllint.yaml') == '' }}
+      run: |-
+        # Create a unique output file outside of the checkout.
+        YAMLLINT_YAML="${RUNNER_TEMP}/${GITHUB_SHA:0:7}.yamllint.yml"
+
+        # Download the file, passing in authentication to get a higher rate
+        # limit: https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
+        curl "${{ inputs.yamllint_url }}" \
+          --silent \
+          --fail \
+          --location \
+          --header "Authorization: Token ${{ github.token }}" \
+          --output "${YAMLLINT_YAML}"
+
+        # Save the result to an output.
+        echo "::notice::Wrote configuration file to ${YAMLLINT_YAML}"
+        echo "output-file=${YAMLLINT_YAML}" >> "${GITHUB_OUTPUT}"
+
+    - name: 'Lint (default configuration)'
+      if: |-
+        ${{ hashFiles('.yamllint.yml', '.yamllint.yaml') == '' }}
+      run: |-
+        yamllint -c "${{ steps.load-default-config.outputs.output-file }}" ${{ inputs.target }}
+
+    - name: 'Lint (custom configuration)'
+      if: |-
+        ${{ hashFiles('.yamllint.yml', '.yamllint.yaml') != '' }}
+      run: |-
+        yamllint ${{ inputs.target }}


### PR DESCRIPTION
### What

New lint actions with the inputs and steps copied from the existing lint workflows.

### Why

1. GH Enterprise Server does not support referencing reusable workflows from github.com (even with github connect) - so if we want to leverage the same shared code it must be a shared action.
3. The strategy for [auto linting](https://docs.google.com/document/d/1nJ4wKycxev8d3-FaMwiP4a3YMMVmseofJIPwbwElIaA/edit?resourcekey=0-OYMYvuqjCVlcEbRpvq4O7w&tab=t.0#heading=h.gqscjct0tgq1) on all repositories will require using reusable actions for each linter instead of reusable workflows. This is because we don't know which linters to run without detecting which files are present in a repo - then we utilize github actions matrix syntax to dynamically run each linter.

### Follow Ups

1. Update the reusable workflows for linting to use these new actions
2. Create the new general purpose lint.yml workflow that may replace the reusable workflows.