### PR TITLE
chore: switch lint to new workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,50 +26,5 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  go_lint:
-    runs-on: 'ubuntu-latest'
-    steps:
-      - name: 'Checkout'
-        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
-
-      - name: 'Lint Go'
-        uses: './.github/actions/lint-go' # ratchet:exclude
-
-  go_modules_lint:
-    runs-on: 'ubuntu-latest'
-    steps:
-      - name: 'Checkout'
-        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
-
-      - name: 'Lint Go Modules'
-        uses: './.github/actions/lint-go-modules' # ratchet:exclude
-
   go_test:
     uses: './.github/workflows/go-test.yml'
-
-  shell_lint:
-    runs-on: 'ubuntu-latest'
-    steps:
-      - name: 'Checkout'
-        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
-
-      - name: 'Lint Shell'
-        uses: './.github/actions/lint-shell' # ratchet:exclude
-
-  terraform_lint:
-    runs-on: 'ubuntu-latest'
-    steps:
-      - name: 'Checkout'
-        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
-
-      - name: 'Lint Terraform'
-        uses: './.github/actions/lint-terraform' # ratchet:exclude
-
-  yaml_lint:
-    runs-on: 'ubuntu-latest'
-    steps:
-      - name: 'Checkout'
-        uses: 'actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683' # ratchet:actions/checkout@v4
-
-      - name: 'Lint Yaml'
-        uses: './.github/actions/lint-yaml' # ratchet:exclude

--- a/.github/workflows/lint-pkg.yml
+++ b/.github/workflows/lint-pkg.yml
@@ -26,6 +26,10 @@ on:
   pull_request:
   merge_group:
 
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   init:
     runs-on: 'ubuntu-latest'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,6 +18,10 @@ on:
   pull_request:
   merge_group:
 
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
+
 jobs:
   init:
     runs-on: 'ubuntu-latest'


### PR DESCRIPTION
Need to update the repo ruleset to add the new required workflows and remove the old ones.