### PR TITLE
chore: add a default.golangci.yml file

### DIFF
--- a/.github/workflows/lint-pkg.yml
+++ b/.github/workflows/lint-pkg.yml
@@ -103,7 +103,7 @@ jobs:
         ${{ vars.GO_LINT_GO_VERSION_FILE || 'go.mod' }}
       # The URL to a golangci file. This is only used if no file is found in the local directory.
       GO_LINT_GOLANGCI_URL: |-
-        ${{ vars.GO_LINT_GOLANGCI_URL || 'https://raw.githubusercontent.com/abcxyz/pkg/main/.golangci.yml' }}
+        ${{ vars.GO_LINT_GOLANGCI_URL || 'https://raw.githubusercontent.com/abcxyz/pkg/main/default.golangci.yml' }}
       # Directory in which Go files reside.
       GO_LINT_DIRECTORY: |-
         ${{ vars.GO_LINT_DIRECTORY || '.' }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -95,7 +95,7 @@ jobs:
         ${{ vars.GO_LINT_GO_VERSION_FILE || 'go.mod' }}
       # The URL to a golangci file. This is only used if no file is found in the local directory.
       GO_LINT_GOLANGCI_URL: |-
-        ${{ vars.GO_LINT_GOLANGCI_URL || 'https://raw.githubusercontent.com/abcxyz/pkg/main/.golangci.yml' }}
+        ${{ vars.GO_LINT_GOLANGCI_URL || 'https://raw.githubusercontent.com/abcxyz/pkg/main/default.golangci.yml' }}
       # Directory in which Go files reside.
       GO_LINT_DIRECTORY: |-
         ${{ vars.GO_LINT_DIRECTORY || '.' }}

--- a/default.golangci.yml
+++ b/default.golangci.yml
@@ -1,0 +1,174 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+run:
+  # default: '1m'
+  timeout: '5m'
+
+  # default: []
+  build-tags:
+    - 'all'
+
+  # default: ''
+  modules-download-mode: 'readonly'
+
+  # default: false
+  allow-parallel-runners: true
+
+linters:
+  enable:
+    - 'asasalint'
+    - 'asciicheck'
+    - 'bidichk'
+    - 'bodyclose'
+    - 'containedctx'
+    - 'copyloopvar'
+    - 'depguard'
+    - 'dupword'
+    - 'durationcheck'
+    - 'errcheck'
+    - 'errchkjson'
+    - 'errname'
+    - 'errorlint'
+    - 'exhaustive'
+    - 'forcetypeassert'
+    - 'gci'
+    - 'gocheckcompilerdirectives'
+    - 'godot'
+    - 'gofmt'
+    - 'gofumpt'
+    - 'goheader'
+    - 'goimports'
+    - 'goprintffuncname'
+    - 'gosec'
+    - 'gosimple'
+    - 'govet'
+    - 'importas'
+    - 'ineffassign'
+    - 'loggercheck'
+    - 'makezero'
+    - 'mirror'
+    - 'misspell'
+    - 'nilerr'
+    - 'noctx'
+    - 'nolintlint'
+    - 'nosprintfhostport'
+    - 'paralleltest'
+    - 'prealloc'
+    - 'predeclared'
+    - 'protogetter'
+    - 'rowserrcheck'
+    - 'sloglint'
+    - 'spancheck'
+    - 'sqlclosecheck'
+    - 'staticcheck'
+    - 'stylecheck'
+    - 'thelper'
+    - 'typecheck'
+    - 'unconvert'
+    - 'unused'
+    - 'usetesting'
+    - 'wastedassign'
+    - 'whitespace'
+    - 'wrapcheck'
+
+issues:
+  # default: []
+  exclude:
+    - '^G102:' # gosec: we have to bind to all ifaces in Cloud Run services
+    - '^G115:' # gosec: there's no way to actually satisfy this linter
+
+  # default: []
+  exclude-rules:
+    # Exclude test files from certain linters
+    - path: '_test.go'
+      linters:
+        - 'wrapcheck'
+
+  # default: []
+  exclude-dirs:
+    - 'internal/pb'
+    - 'third_party'
+
+  # default: true
+  exclude-dirs-use-default: false
+
+  # default: 50
+  max-issues-per-linter: 0
+
+  # default: 3
+  max-same-issues: 0
+
+linters-settings:
+  depguard:
+    rules:
+      main:
+        files:
+          - '$all'
+        deny:
+          - pkg: 'github.com/auth0/go-jwt-middleware'
+            desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
+          - pkg: 'github.com/gin-contrib/*'
+            desc: 'third-party web frameworks are not approved, use net/http'
+          - pkg: 'github.com/gin-gonic/contrib'
+            desc: 'third-party web frameworks are not approved, use net/http'
+          - pkg: 'github.com/gin-gonic/gin'
+            desc: 'third-party web frameworks are not approved, use net/http'
+          - pkg: 'github.com/golang-jwt/jwe'
+            desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
+          - pkg: 'github.com/golang-jwt/jwt'
+            desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
+          - pkg: 'github.com/stretchr/testify'
+            desc: 'use the standard library for tests'
+
+  gci:
+    sections:
+      - 'standard'
+      - 'default'
+      - 'blank'
+      - 'dot'
+
+    skip-generated: true
+    custom-order: true
+
+  gofumpt:
+    # default: false
+    extra-rules: true
+
+  sloglint:
+    # default: false
+    context: 'all'
+    # default: false
+    static-msg: false
+    # default: '' (snake, kebab, camel, pascal)
+    key-naming-case: 'snake'
+    # default: false
+    args-on-sep-lines: true
+
+  usetesting:
+    # default: false
+    os-temp-dir: true
+
+  wrapcheck:
+    ignoreSigRegexps:
+      - '\.ErrorOrNil\('
+      - '\.StartGRPC\('
+      - '\.StartHTTP\('
+      - '\.StartHTTPHandler\('
+      - 'retry\.RetryableError\('
+      - 'status\.Error\('
+
+severity:
+  # default: ''
+  default-severity: 'error'


### PR DESCRIPTION
This golangci config file will be used everywhere except in this org.

In our org we will continue to use the `.golangci.yml` file (set via org var)
```
GO_LINT_GOLANGCI_URL=https://raw.githubusercontent.com/abcxyz/pkg/main/.golangci.yml
```