### PR TITLE
feat: add a reusable workflow to check if PR has description

### DIFF
--- a/.github/workflows/check-pr-description.yml
+++ b/.github/workflows/check-pr-description.yml
@@ -3,9 +3,9 @@ name: 'Check PR Description'
 on:
   workflow_call:
     inputs:
-      pull_request_body: 
+      pull_request_body:
         description: 'The body of the pull request'
-        type: string
+        type: 'string'
 
 jobs:
   check-description:

--- a/.github/workflows/check-pr-description.yml
+++ b/.github/workflows/check-pr-description.yml
@@ -1,12 +1,12 @@
 name: Check PR Description
 
 on:
-  pull_request:
-    types: [opened, edited]
+  workflow_call:
 
 jobs:
   check-description:
     runs-on: ubuntu-latest
+
     steps:
       # Step to check if the pull request description is empty
       - name: Check PR Description Not Empty

--- a/.github/workflows/check-pr-description.yml
+++ b/.github/workflows/check-pr-description.yml
@@ -1,0 +1,20 @@
+name: Check PR Description
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  check-description:
+    runs-on: ubuntu-latest
+    steps:
+      # Step to check if the pull request description is empty
+      - name: Check PR Description Not Empty
+        run: |
+          if [[ -z "${{ github.event.pull_request.body }}" ]]; then
+            echo "Error: Pull request description cannot be empty."
+            exit 1
+          else
+            echo "Pull request description is not empty."
+            exit 0
+          fi

--- a/.github/workflows/check-pr-description.yml
+++ b/.github/workflows/check-pr-description.yml
@@ -1,17 +1,21 @@
-name: Check PR Description
+name: 'Check PR Description'
 
 on:
   workflow_call:
+    inputs:
+      pull_request_body: 
+        description: 'The body of the pull request'
+        type: string
 
 jobs:
   check-description:
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-latest'
 
     steps:
       # Step to check if the pull request description is empty
-      - name: Check PR Description Not Empty
+      - name: 'Check PR Description Not Empty'
         run: |
-          if [[ -z "${{ github.event.pull_request.body }}" ]]; then
+          if [[ -z "${{ inputs.pull_request_body }}" ]]; then
             echo "Error: Pull request description cannot be empty."
             exit 1
           else


### PR DESCRIPTION
This PR add a new workflow that can be triggered by `workflow_call`. It will fail if the description is empty.