### PR TITLE
Mark multi-approvers workflow as deprecated

### DIFF
--- a/.github/workflows/multi-approvers.js
+++ b/.github/workflows/multi-approvers.js
@@ -38,6 +38,8 @@ function inOrgApprovedCount(members, submittedReviews, prLogin) {
 
 /** Checks that approval requirements are satisfied. */
 async function onPullRequest({orgMembersPath, prNumber, repoName, repoOwner, github, core}) {
+  core.warning("This workflow is deprecated. Please migrate to the new multi-approvers action found at https://github.com/abcxyz/actions/tree/main/.github/actions/multi-approvers.");
+
   const members = require(orgMembersPath).reduce((acc, v) => acc.set(v.login, v), new Map());
   const prResponse = await github.rest.pulls.get({owner: repoOwner, repo: repoName, pull_number: prNumber});
   const prLogin = prResponse.data.user.login;
@@ -70,6 +72,8 @@ async function onPullRequest({orgMembersPath, prNumber, repoName, repoOwner, git
  * pull_request_review as different status checks.
  */
 async function onPullRequestReview({workflowRef, repoName, repoOwner, branch, prNumber, github, core}) {
+  core.warning("This workflow is deprecated. Please migrate to the new multi-approvers action found at https://github.com/abcxyz/actions/tree/main/.github/actions/multi-approvers.");
+
   // Get the filename of the workflow.
   const workflowFilename = workflowRef.split('@')[0].split('/').pop();
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,22 @@ approval from all requested reviewers.
 An admin will need to create a new ruleset within the repo to add want_lgtm_all to be included
 as a required status check.
 
-#### multi-approvers.yml
+#### [DEPRECATED] multi-approvers.yml
+
+> [!CAUTION]
+> This workflow will be deprecated on **September 2nd, 2025**.
+
+> [!WARNING]
+> Use the new [multi-approvers Action](https://github.com/abcxyz/actions/tree/main/.github/actions/multi-approvers) instead. 
+
+**Migration instructions**
+
+To migrate from this deprecated workflow to the new action one must translate
+the JSON member file to a GitHub Team. The new action does not support JSON
+member files and is therefore not backward compatible with the original
+multi-approver workflow.
+
+**[DEPRECATED] Instructions**
 
 Use this workflow to require two in-org approvers for pull requests sent from an
 out-of-org user. This prevents in-org users from creating "sock puppet" accounts


### PR DESCRIPTION
Update the README with deprecation date (September 2, 2025) and
migration instructions to the new multi-approvers action.
