### PR TITLE
chore: update golangci lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,83 +12,83 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "2"
+version: '2'
 run:
   build-tags:
-    - all
-  modules-download-mode: readonly
+    - 'all'
+  modules-download-mode: 'readonly'
   allow-parallel-runners: true
 linters:
   enable:
-    - asasalint
-    - asciicheck
-    - bidichk
-    - bodyclose
-    - containedctx
-    - copyloopvar
-    - depguard
-    - dupword
-    - durationcheck
-    - errchkjson
-    - errname
-    - errorlint
-    - exhaustive
-    - forcetypeassert
-    - gocheckcompilerdirectives
-    - godot
-    - goheader
-    - goprintffuncname
-    - gosec
-    - importas
-    - loggercheck
-    - makezero
-    - mirror
-    - misspell
-    - nilerr
-    - noctx
-    - nolintlint
-    - nosprintfhostport
-    - paralleltest
-    - prealloc
-    - predeclared
-    - protogetter
-    - rowserrcheck
-    - sloglint
-    - spancheck
-    - sqlclosecheck
-    - staticcheck
-    - thelper
-    - unconvert
-    - usetesting
-    - wastedassign
-    - whitespace
-    - wrapcheck
+    - 'asasalint'
+    - 'asciicheck'
+    - 'bidichk'
+    - 'bodyclose'
+    - 'containedctx'
+    - 'copyloopvar'
+    - 'depguard'
+    - 'dupword'
+    - 'durationcheck'
+    - 'errchkjson'
+    - 'errname'
+    - 'errorlint'
+    - 'exhaustive'
+    - 'forcetypeassert'
+    - 'gocheckcompilerdirectives'
+    - 'godot'
+    - 'goheader'
+    - 'goprintffuncname'
+    - 'gosec'
+    - 'importas'
+    - 'loggercheck'
+    - 'makezero'
+    - 'mirror'
+    - 'misspell'
+    - 'nilerr'
+    - 'noctx'
+    - 'nolintlint'
+    - 'nosprintfhostport'
+    - 'paralleltest'
+    - 'prealloc'
+    - 'predeclared'
+    - 'protogetter'
+    - 'rowserrcheck'
+    - 'sloglint'
+    - 'spancheck'
+    - 'sqlclosecheck'
+    - 'staticcheck'
+    - 'thelper'
+    - 'unconvert'
+    - 'usetesting'
+    - 'wastedassign'
+    - 'whitespace'
+    - 'wrapcheck'
   settings:
     depguard:
       rules:
         main:
           files:
-            - $all
+            - '$all'
           deny:
-            - pkg: github.com/auth0/go-jwt-middleware
-              desc: the approved jwx library is github.com/lestrrat-go/jwx/v2
-            - pkg: github.com/gin-contrib/*
-              desc: third-party web frameworks are not approved, use net/http
-            - pkg: github.com/gin-gonic/contrib
-              desc: third-party web frameworks are not approved, use net/http
-            - pkg: github.com/gin-gonic/gin
-              desc: third-party web frameworks are not approved, use net/http
-            - pkg: github.com/golang-jwt/jwe
-              desc: the approved jwx library is github.com/lestrrat-go/jwx/v2
-            - pkg: github.com/golang-jwt/jwt
-              desc: the approved jwx library is github.com/lestrrat-go/jwx/v2
-            - pkg: github.com/stretchr/testify
-              desc: use the standard library for tests
+            - pkg: 'github.com/auth0/go-jwt-middleware'
+              desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
+            - pkg: 'github.com/gin-contrib/*'
+              desc: 'third-party web frameworks are not approved, use net/http'
+            - pkg: 'github.com/gin-gonic/contrib'
+              desc: 'third-party web frameworks are not approved, use net/http'
+            - pkg: 'github.com/gin-gonic/gin'
+              desc: 'third-party web frameworks are not approved, use net/http'
+            - pkg: 'github.com/golang-jwt/jwe'
+              desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
+            - pkg: 'github.com/golang-jwt/jwt'
+              desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
+            - pkg: 'github.com/stretchr/testify'
+              desc: 'use the standard library for tests'
     goheader:
       values:
         regexp:
           INDENTATION: '[\t\f]+|[ ]{2,}'
-          YEAR_AUTHOR: \d{4} .*
+          YEAR_AUTHOR: '\d{4} .*'
       template: |-
         Copyright {{ YEAR_AUTHOR }}
 
@@ -104,62 +104,62 @@ linters:
         See the License for the specific language governing permissions and
         limitations under the License.
     sloglint:
-      context: all
+      context: 'all'
       static-msg: false
-      key-naming-case: snake
+      key-naming-case: 'snake'
       args-on-sep-lines: true
     usetesting:
       os-temp-dir: true
     wrapcheck:
       ignore-sig-regexps:
-        - \.ErrorOrNil\(
-        - \.StartGRPC\(
-        - \.StartHTTP\(
-        - \.StartHTTPHandler\(
-        - retry\.RetryableError\(
-        - status\.Error\(
+        - '\.ErrorOrNil\('
+        - '\.StartGRPC\('
+        - '\.StartHTTP\('
+        - '\.StartHTTPHandler\('
+        - 'retry\.RetryableError\('
+        - 'status\.Error\('
   exclusions:
-    generated: lax
+    generated: 'lax'
     presets:
-      - comments
-      - common-false-positives
-      - legacy
-      - std-error-handling
+      - 'comments'
+      - 'common-false-positives'
+      - 'legacy'
+      - 'std-error-handling'
     rules:
       - linters:
-          - wrapcheck
-        path: _test.go
-      - path: (.+)\.go$
-        text: '^G102:'
-      - path: (.+)\.go$
-        text: '^G115:'
+          - 'wrapcheck'
+        path: '_test.go'
+      - path: '(.+)\.go$'
+        text: '^G102:' # gosec: we have to bind to all ifaces in Cloud Run services
+      - path: '(.+)\.go$'
+        text: '^G115:' # gosec: there's no way to actually satisfy this linter
     paths:
-      - internal/pb
-      - third_party
+      - 'internal/pb'
+      - 'third_party'
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
 severity:
-  default: error
+  default: 'error'
 formatters:
   enable:
-    - gci
-    - gofmt
-    - gofumpt
-    - goimports
+    - 'gci'
+    - 'gofmt'
+    - 'gofumpt'
+    - 'goimports'
   settings:
     gci:
       sections:
-        - standard
-        - default
-        - prefix(github.com/abcxyz)
-        - blank
-        - dot
+        - 'standard'
+        - 'default'
+        - 'prefix(github.com/abcxyz)'
+        - 'blank'
+        - 'dot'
       custom-order: true
     gofumpt:
       extra-rules: true
   exclusions:
-    generated: lax
+    generated: 'lax'
     paths:
-      - internal/pb
-      - third_party
+      - 'internal/pb'
+      - 'third_party'

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,185 +12,154 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: "2"
 run:
-  # default: '1m'
-  timeout: '5m'
-
-  # default: []
   build-tags:
-    - 'all'
-
-  # default: ''
-  modules-download-mode: 'readonly'
-
-  # default: false
+    - all
+  modules-download-mode: readonly
   allow-parallel-runners: true
-
 linters:
   enable:
-    - 'asasalint'
-    - 'asciicheck'
-    - 'bidichk'
-    - 'bodyclose'
-    - 'containedctx'
-    - 'copyloopvar'
-    - 'depguard'
-    - 'dupword'
-    - 'durationcheck'
-    - 'errcheck'
-    - 'errchkjson'
-    - 'errname'
-    - 'errorlint'
-    - 'exhaustive'
-    - 'forcetypeassert'
-    - 'gci'
-    - 'gocheckcompilerdirectives'
-    - 'godot'
-    - 'gofmt'
-    - 'gofumpt'
-    - 'goheader'
-    - 'goimports'
-    - 'goprintffuncname'
-    - 'gosec'
-    - 'gosimple'
-    - 'govet'
-    - 'importas'
-    - 'ineffassign'
-    - 'loggercheck'
-    - 'makezero'
-    - 'mirror'
-    - 'misspell'
-    - 'nilerr'
-    - 'noctx'
-    - 'nolintlint'
-    - 'nosprintfhostport'
-    - 'paralleltest'
-    - 'prealloc'
-    - 'predeclared'
-    - 'protogetter'
-    - 'rowserrcheck'
-    - 'sloglint'
-    - 'spancheck'
-    - 'sqlclosecheck'
-    - 'staticcheck'
-    - 'stylecheck'
-    - 'thelper'
-    - 'typecheck'
-    - 'unconvert'
-    - 'unused'
-    - 'usetesting'
-    - 'wastedassign'
-    - 'whitespace'
-    - 'wrapcheck'
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - containedctx
+    - copyloopvar
+    - depguard
+    - dupword
+    - durationcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - exhaustive
+    - forcetypeassert
+    - gocheckcompilerdirectives
+    - godot
+    - goheader
+    - goprintffuncname
+    - gosec
+    - importas
+    - loggercheck
+    - makezero
+    - mirror
+    - misspell
+    - nilerr
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    - paralleltest
+    - prealloc
+    - predeclared
+    - protogetter
+    - rowserrcheck
+    - sloglint
+    - spancheck
+    - sqlclosecheck
+    - staticcheck
+    - thelper
+    - unconvert
+    - usetesting
+    - wastedassign
+    - whitespace
+    - wrapcheck
+  settings:
+    depguard:
+      rules:
+        main:
+          files:
+            - $all
+          deny:
+            - pkg: github.com/auth0/go-jwt-middleware
+              desc: the approved jwx library is github.com/lestrrat-go/jwx/v2
+            - pkg: github.com/gin-contrib/*
+              desc: third-party web frameworks are not approved, use net/http
+            - pkg: github.com/gin-gonic/contrib
+              desc: third-party web frameworks are not approved, use net/http
+            - pkg: github.com/gin-gonic/gin
+              desc: third-party web frameworks are not approved, use net/http
+            - pkg: github.com/golang-jwt/jwe
+              desc: the approved jwx library is github.com/lestrrat-go/jwx/v2
+            - pkg: github.com/golang-jwt/jwt
+              desc: the approved jwx library is github.com/lestrrat-go/jwx/v2
+            - pkg: github.com/stretchr/testify
+              desc: use the standard library for tests
+    goheader:
+      values:
+        regexp:
+          INDENTATION: '[\t\f]+|[ ]{2,}'
+          YEAR_AUTHOR: \d{4} .*
+      template: |-
+        Copyright {{ YEAR_AUTHOR }}
 
-issues:
-  # default: []
-  exclude:
-    - '^G102:' # gosec: we have to bind to all ifaces in Cloud Run services
-    - '^G115:' # gosec: there's no way to actually satisfy this linter
+        Licensed under the Apache License, Version 2.0 (the "License");
+        you may not use this file except in compliance with the License.
+        You may obtain a copy of the License at
 
-  # default: []
-  exclude-rules:
-    # Exclude test files from certain linters
-    - path: '_test.go'
-      linters:
-        - 'wrapcheck'
+        {{ INDENTATION }}http://www.apache.org/licenses/LICENSE-2.0
 
-  # default: []
-  exclude-dirs:
-    - 'internal/pb'
-    - 'third_party'
-
-  # default: true
-  exclude-dirs-use-default: false
-
-  # default: 50
-  max-issues-per-linter: 0
-
-  # default: 3
-  max-same-issues: 0
-
-linters-settings:
-  depguard:
+        Unless required by applicable law or agreed to in writing, software
+        distributed under the License is distributed on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+        See the License for the specific language governing permissions and
+        limitations under the License.
+    sloglint:
+      context: all
+      static-msg: false
+      key-naming-case: snake
+      args-on-sep-lines: true
+    usetesting:
+      os-temp-dir: true
+    wrapcheck:
+      ignore-sig-regexps:
+        - \.ErrorOrNil\(
+        - \.StartGRPC\(
+        - \.StartHTTP\(
+        - \.StartHTTPHandler\(
+        - retry\.RetryableError\(
+        - status\.Error\(
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      main:
-        files:
-          - '$all'
-        deny:
-          - pkg: 'github.com/auth0/go-jwt-middleware'
-            desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
-          - pkg: 'github.com/gin-contrib/*'
-            desc: 'third-party web frameworks are not approved, use net/http'
-          - pkg: 'github.com/gin-gonic/contrib'
-            desc: 'third-party web frameworks are not approved, use net/http'
-          - pkg: 'github.com/gin-gonic/gin'
-            desc: 'third-party web frameworks are not approved, use net/http'
-          - pkg: 'github.com/golang-jwt/jwe'
-            desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
-          - pkg: 'github.com/golang-jwt/jwt'
-            desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
-          - pkg: 'github.com/stretchr/testify'
-            desc: 'use the standard library for tests'
-
-  gci:
-    sections:
-      - 'standard'
-      - 'default'
-      - 'prefix(github.com/abcxyz)'
-      - 'blank'
-      - 'dot'
-
-    skip-generated: true
-    custom-order: true
-
-  gofumpt:
-    # default: false
-    extra-rules: true
-
-  goheader:
-    values:
-      regexp:
-        YEAR_AUTHOR: '\d{4} .*'
-        INDENTATION: '[\t\f]+|[ ]{2,}'
-    # default: ""
-    template: |-
-      Copyright {{ YEAR_AUTHOR }}
-
-      Licensed under the Apache License, Version 2.0 (the "License");
-      you may not use this file except in compliance with the License.
-      You may obtain a copy of the License at
-
-      {{ INDENTATION }}http://www.apache.org/licenses/LICENSE-2.0
-
-      Unless required by applicable law or agreed to in writing, software
-      distributed under the License is distributed on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-      See the License for the specific language governing permissions and
-      limitations under the License.
-
-  sloglint:
-    # default: false
-    context: 'all'
-    # default: false
-    static-msg: false
-    # default: '' (snake, kebab, camel, pascal)
-    key-naming-case: 'snake'
-    # default: false
-    args-on-sep-lines: true
-
-  usetesting:
-    # default: false
-    os-temp-dir: true
-
-  wrapcheck:
-    ignoreSigRegexps:
-      - '\.ErrorOrNil\('
-      - '\.StartGRPC\('
-      - '\.StartHTTP\('
-      - '\.StartHTTPHandler\('
-      - 'retry\.RetryableError\('
-      - 'status\.Error\('
-
+      - linters:
+          - wrapcheck
+        path: _test.go
+      - path: (.+)\.go$
+        text: '^G102:'
+      - path: (.+)\.go$
+        text: '^G115:'
+    paths:
+      - internal/pb
+      - third_party
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 severity:
-  # default: ''
-  default-severity: 'error'
+  default: error
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/abcxyz)
+        - blank
+        - dot
+      custom-order: true
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
+    paths:
+      - internal/pb
+      - third_party

--- a/default.golangci.yml
+++ b/default.golangci.yml
@@ -12,163 +12,134 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+version: "2"
 run:
-  # default: '1m'
-  timeout: '5m'
-
-  # default: []
   build-tags:
-    - 'all'
-
-  # default: ''
-  modules-download-mode: 'readonly'
-
-  # default: false
+    - all
+  modules-download-mode: readonly
   allow-parallel-runners: true
-
 linters:
   enable:
-    - 'asasalint'
-    - 'asciicheck'
-    - 'bidichk'
-    - 'bodyclose'
-    - 'containedctx'
-    - 'copyloopvar'
-    - 'depguard'
-    - 'dupword'
-    - 'durationcheck'
-    - 'errcheck'
-    - 'errchkjson'
-    - 'errname'
-    - 'errorlint'
-    - 'exhaustive'
-    - 'forcetypeassert'
-    - 'gci'
-    - 'gocheckcompilerdirectives'
-    - 'godot'
-    - 'gofmt'
-    - 'gofumpt'
-    - 'goheader'
-    - 'goimports'
-    - 'goprintffuncname'
-    - 'gosec'
-    - 'gosimple'
-    - 'govet'
-    - 'importas'
-    - 'ineffassign'
-    - 'loggercheck'
-    - 'makezero'
-    - 'mirror'
-    - 'misspell'
-    - 'nilerr'
-    - 'noctx'
-    - 'nolintlint'
-    - 'nosprintfhostport'
-    - 'paralleltest'
-    - 'prealloc'
-    - 'predeclared'
-    - 'protogetter'
-    - 'rowserrcheck'
-    - 'sloglint'
-    - 'spancheck'
-    - 'sqlclosecheck'
-    - 'staticcheck'
-    - 'stylecheck'
-    - 'thelper'
-    - 'typecheck'
-    - 'unconvert'
-    - 'unused'
-    - 'usetesting'
-    - 'wastedassign'
-    - 'whitespace'
-    - 'wrapcheck'
-
-issues:
-  # default: []
-  exclude:
-    - '^G102:' # gosec: we have to bind to all ifaces in Cloud Run services
-    - '^G115:' # gosec: there's no way to actually satisfy this linter
-
-  # default: []
-  exclude-rules:
-    # Exclude test files from certain linters
-    - path: '_test.go'
-      linters:
-        - 'wrapcheck'
-
-  # default: []
-  exclude-dirs:
-    - 'internal/pb'
-    - 'third_party'
-
-  # default: true
-  exclude-dirs-use-default: false
-
-  # default: 50
-  max-issues-per-linter: 0
-
-  # default: 3
-  max-same-issues: 0
-
-linters-settings:
-  depguard:
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - containedctx
+    - copyloopvar
+    - depguard
+    - dupword
+    - durationcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - exhaustive
+    - forcetypeassert
+    - gocheckcompilerdirectives
+    - godot
+    - goheader
+    - goprintffuncname
+    - gosec
+    - importas
+    - loggercheck
+    - makezero
+    - mirror
+    - misspell
+    - nilerr
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    - paralleltest
+    - prealloc
+    - predeclared
+    - protogetter
+    - rowserrcheck
+    - sloglint
+    - spancheck
+    - sqlclosecheck
+    - staticcheck
+    - thelper
+    - unconvert
+    - usetesting
+    - wastedassign
+    - whitespace
+    - wrapcheck
+  settings:
+    depguard:
+      rules:
+        main:
+          files:
+            - $all
+          deny:
+            - pkg: github.com/auth0/go-jwt-middleware
+              desc: the approved jwx library is github.com/lestrrat-go/jwx/v2
+            - pkg: github.com/gin-contrib/*
+              desc: third-party web frameworks are not approved, use net/http
+            - pkg: github.com/gin-gonic/contrib
+              desc: third-party web frameworks are not approved, use net/http
+            - pkg: github.com/gin-gonic/gin
+              desc: third-party web frameworks are not approved, use net/http
+            - pkg: github.com/golang-jwt/jwe
+              desc: the approved jwx library is github.com/lestrrat-go/jwx/v2
+            - pkg: github.com/golang-jwt/jwt
+              desc: the approved jwx library is github.com/lestrrat-go/jwx/v2
+            - pkg: github.com/stretchr/testify
+              desc: use the standard library for tests
+    sloglint:
+      context: all
+      static-msg: false
+      key-naming-case: snake
+      args-on-sep-lines: true
+    usetesting:
+      os-temp-dir: true
+    wrapcheck:
+      ignore-sig-regexps:
+        - \.ErrorOrNil\(
+        - \.StartGRPC\(
+        - \.StartHTTP\(
+        - \.StartHTTPHandler\(
+        - retry\.RetryableError\(
+        - status\.Error\(
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      main:
-        files:
-          - '$all'
-        deny:
-          - pkg: 'github.com/auth0/go-jwt-middleware'
-            desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
-          - pkg: 'github.com/gin-contrib/*'
-            desc: 'third-party web frameworks are not approved, use net/http'
-          - pkg: 'github.com/gin-gonic/contrib'
-            desc: 'third-party web frameworks are not approved, use net/http'
-          - pkg: 'github.com/gin-gonic/gin'
-            desc: 'third-party web frameworks are not approved, use net/http'
-          - pkg: 'github.com/golang-jwt/jwe'
-            desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
-          - pkg: 'github.com/golang-jwt/jwt'
-            desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
-          - pkg: 'github.com/stretchr/testify'
-            desc: 'use the standard library for tests'
-
-  gci:
-    sections:
-      - 'standard'
-      - 'default'
-      - 'blank'
-      - 'dot'
-
-    skip-generated: true
-    custom-order: true
-
-  gofumpt:
-    # default: false
-    extra-rules: true
-
-  sloglint:
-    # default: false
-    context: 'all'
-    # default: false
-    static-msg: false
-    # default: '' (snake, kebab, camel, pascal)
-    key-naming-case: 'snake'
-    # default: false
-    args-on-sep-lines: true
-
-  usetesting:
-    # default: false
-    os-temp-dir: true
-
-  wrapcheck:
-    ignoreSigRegexps:
-      - '\.ErrorOrNil\('
-      - '\.StartGRPC\('
-      - '\.StartHTTP\('
-      - '\.StartHTTPHandler\('
-      - 'retry\.RetryableError\('
-      - 'status\.Error\('
-
+      - linters:
+          - wrapcheck
+        path: _test.go
+      - path: (.+)\.go$
+        text: '^G102:'
+      - path: (.+)\.go$
+        text: '^G115:'
+    paths:
+      - internal/pb
+      - third_party
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 severity:
-  # default: ''
-  default-severity: 'error'
+  default: error
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - gofumpt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - blank
+        - dot
+      custom-order: true
+    gofumpt:
+      extra-rules: true
+  exclusions:
+    generated: lax
+    paths:
+      - internal/pb
+      - third_party

--- a/default.golangci.yml
+++ b/default.golangci.yml
@@ -1,145 +1,145 @@
 # Copyright 2023 The Authors (see AUTHORS file)
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
+# Licensed under the Apache License, Version 2.0 (the 'License');
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
 #      http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
+# distributed under the License is distributed on an 'AS IS' BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version: "2"
+version: '2'
 run:
   build-tags:
-    - all
-  modules-download-mode: readonly
+    - 'all'
+  modules-download-mode: 'readonly'
   allow-parallel-runners: true
 linters:
   enable:
-    - asasalint
-    - asciicheck
-    - bidichk
-    - bodyclose
-    - containedctx
-    - copyloopvar
-    - depguard
-    - dupword
-    - durationcheck
-    - errchkjson
-    - errname
-    - errorlint
-    - exhaustive
-    - forcetypeassert
-    - gocheckcompilerdirectives
-    - godot
-    - goheader
-    - goprintffuncname
-    - gosec
-    - importas
-    - loggercheck
-    - makezero
-    - mirror
-    - misspell
-    - nilerr
-    - noctx
-    - nolintlint
-    - nosprintfhostport
-    - paralleltest
-    - prealloc
-    - predeclared
-    - protogetter
-    - rowserrcheck
-    - sloglint
-    - spancheck
-    - sqlclosecheck
-    - staticcheck
-    - thelper
-    - unconvert
-    - usetesting
-    - wastedassign
-    - whitespace
-    - wrapcheck
+    - 'asasalint'
+    - 'asciicheck'
+    - 'bidichk'
+    - 'bodyclose'
+    - 'containedctx'
+    - 'copyloopvar'
+    - 'depguard'
+    - 'dupword'
+    - 'durationcheck'
+    - 'errchkjson'
+    - 'errname'
+    - 'errorlint'
+    - 'exhaustive'
+    - 'forcetypeassert'
+    - 'gocheckcompilerdirectives'
+    - 'godot'
+    - 'goheader'
+    - 'goprintffuncname'
+    - 'gosec'
+    - 'importas'
+    - 'loggercheck'
+    - 'makezero'
+    - 'mirror'
+    - 'misspell'
+    - 'nilerr'
+    - 'noctx'
+    - 'nolintlint'
+    - 'nosprintfhostport'
+    - 'paralleltest'
+    - 'prealloc'
+    - 'predeclared'
+    - 'protogetter'
+    - 'rowserrcheck'
+    - 'sloglint'
+    - 'spancheck'
+    - 'sqlclosecheck'
+    - 'staticcheck'
+    - 'thelper'
+    - 'unconvert'
+    - 'usetesting'
+    - 'wastedassign'
+    - 'whitespace'
+    - 'wrapcheck'
   settings:
     depguard:
       rules:
         main:
           files:
-            - $all
+            - '$all'
           deny:
-            - pkg: github.com/auth0/go-jwt-middleware
-              desc: the approved jwx library is github.com/lestrrat-go/jwx/v2
-            - pkg: github.com/gin-contrib/*
-              desc: third-party web frameworks are not approved, use net/http
-            - pkg: github.com/gin-gonic/contrib
-              desc: third-party web frameworks are not approved, use net/http
-            - pkg: github.com/gin-gonic/gin
-              desc: third-party web frameworks are not approved, use net/http
-            - pkg: github.com/golang-jwt/jwe
-              desc: the approved jwx library is github.com/lestrrat-go/jwx/v2
-            - pkg: github.com/golang-jwt/jwt
-              desc: the approved jwx library is github.com/lestrrat-go/jwx/v2
-            - pkg: github.com/stretchr/testify
-              desc: use the standard library for tests
+            - pkg: 'github.com/auth0/go-jwt-middleware'
+              desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
+            - pkg: 'github.com/gin-contrib/*'
+              desc: 'third-party web frameworks are not approved, use net/http'
+            - pkg: 'github.com/gin-gonic/contrib'
+              desc: 'third-party web frameworks are not approved, use net/http'
+            - pkg: 'github.com/gin-gonic/gin'
+              desc: 'third-party web frameworks are not approved, use net/http'
+            - pkg: 'github.com/golang-jwt/jwe'
+              desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
+            - pkg: 'github.com/golang-jwt/jwt'
+              desc: 'the approved jwx library is github.com/lestrrat-go/jwx/v2'
+            - pkg: 'github.com/stretchr/testify'
+              desc: 'use the standard library for tests'
     sloglint:
-      context: all
+      context: 'all'
       static-msg: false
-      key-naming-case: snake
+      key-naming-case: 'snake'
       args-on-sep-lines: true
     usetesting:
       os-temp-dir: true
     wrapcheck:
       ignore-sig-regexps:
-        - \.ErrorOrNil\(
-        - \.StartGRPC\(
-        - \.StartHTTP\(
-        - \.StartHTTPHandler\(
-        - retry\.RetryableError\(
-        - status\.Error\(
+        - '\.ErrorOrNil\('
+        - '\.StartGRPC\('
+        - '\.StartHTTP\('
+        - '\.StartHTTPHandler\('
+        - 'retry\.RetryableError\('
+        - 'status\.Error\('
   exclusions:
-    generated: lax
+    generated: 'lax'
     presets:
-      - comments
-      - common-false-positives
-      - legacy
-      - std-error-handling
+      - 'comments'
+      - 'common-false-positives'
+      - 'legacy'
+      - 'std-error-handling'
     rules:
       - linters:
-          - wrapcheck
-        path: _test.go
-      - path: (.+)\.go$
-        text: '^G102:'
-      - path: (.+)\.go$
-        text: '^G115:'
+          - 'wrapcheck'
+        path: '_test.go'
+      - path: '(.+)\.go$'
+        text: '^G102:' # gosec: we have to bind to all ifaces in Cloud Run services
+      - path: '(.+)\.go$'
+        text: '^G115:' # gosec: there's no way to actually satisfy this linter
     paths:
-      - internal/pb
-      - third_party
+      - 'internal/pb'
+      - 'third_party'
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0
 severity:
-  default: error
+  default: 'error'
 formatters:
   enable:
-    - gci
-    - gofmt
-    - gofumpt
-    - goimports
+    - 'gci'
+    - 'gofmt'
+    - 'gofumpt'
+    - 'goimports'
   settings:
     gci:
       sections:
-        - standard
-        - default
-        - blank
-        - dot
+        - 'standard'
+        - 'default'
+        - 'blank'
+        - 'dot'
       custom-order: true
     gofumpt:
       extra-rules: true
   exclusions:
-    generated: lax
+    generated: 'lax'
     paths:
-      - internal/pb
-      - third_party
+      - 'internal/pb'
+      - 'third_party'

--- a/logging/logger_test.go
+++ b/logging/logger_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"log/slog"
 	"strings"
 	"testing"
@@ -222,8 +221,8 @@ func TestDefaultLogger(t *testing.T) {
 func TestContext(t *testing.T) {
 	t.Parallel()
 
-	logger1 := slog.New(slog.NewTextHandler(io.Discard, nil))
-	logger2 := slog.New(slog.NewTextHandler(io.Discard, nil))
+	logger1 := slog.New(slog.DiscardHandler)
+	logger2 := slog.New(slog.DiscardHandler)
 
 	checkFromContext(t.Context(), t, DefaultLogger())
 


### PR DESCRIPTION
used command "golangci-lint migrate"

This is to fix: https://github.com/abcxyz/github-metrics-aggregator/actions/runs/16375792187/job/46402040201